### PR TITLE
output prisma outside of node_modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/prisma/client

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ./node_modules
-        key: nodemodules-cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('patches/**.patch', 'prisma/schema.prisma') }}
+        key: nodemodules-cache-${{ hashFiles('package-lock.json') }}-${{ hashFiles('patches/**.patch') }}
 
     - name: Install npm dependencies
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ dist
 .env.local
 .env.test.local
 .env.production
-src/.env.production
+src/.env*
+src/prisma/client
 
 # ignore package-lock - it is not used in downstream projects
 package-lock.json

--- a/src/lib/forums/posts/interfaces.ts
+++ b/src/lib/forums/posts/interfaces.ts
@@ -1,3 +1,3 @@
-import type { Post, PostUpDownVote } from '@prisma/client';
+import type { Post, PostUpDownVote } from '../../../prisma';
 
 export type ForumPostWithVotes = Post & { upDownVotes: Pick<PostUpDownVote, 'upvoted' | 'createdBy'> };

--- a/src/lib/permissions/__tests__/hasAccessToSpace.spec.ts
+++ b/src/lib/permissions/__tests__/hasAccessToSpace.spec.ts
@@ -1,8 +1,8 @@
-import type { Space, User } from '@prisma/client';
 import { InvalidInputError, AdministratorOnlyError, UserIsGuestError, UserIsNotSpaceMemberError } from 'lib/errors';
 import { generateUserAndSpace, generateSpaceUser } from 'lib/testing/user';
 import { uid } from 'lib/utilities/strings';
 
+import type { Space, User } from '../../../prisma';
 import { prisma } from '../../../prisma-client';
 import { hasAccessToSpace } from '../hasAccessToSpace';
 

--- a/src/lib/permissions/forums/availablePostCategoryPermissions.class.ts
+++ b/src/lib/permissions/forums/availablePostCategoryPermissions.class.ts
@@ -1,5 +1,4 @@
-import { PostCategoryOperation } from '@prisma/client';
-
+import { PostCategoryOperation } from '../../../prisma';
 import { typedKeys } from '../../utilities/objects';
 import { BasePermissions } from '../core/basePermissions.class';
 

--- a/src/lib/permissions/forums/availablePostPermissions.class.ts
+++ b/src/lib/permissions/forums/availablePostPermissions.class.ts
@@ -1,5 +1,4 @@
-import { PostOperation } from '@prisma/client';
-
+import { PostOperation } from '../../../prisma';
 import { typedKeys } from '../../utilities/objects';
 import { BasePermissions } from '../core/basePermissions.class';
 

--- a/src/lib/permissions/forums/interfaces.ts
+++ b/src/lib/permissions/forums/interfaces.ts
@@ -1,6 +1,5 @@
-import { PostCategoryOperation, PostOperation } from '@prisma/client';
-import type { PostCategory, PostCategoryPermissionLevel } from '@prisma/client';
-
+import { PostCategoryOperation, PostOperation } from '../../../prisma';
+import type { PostCategory, PostCategoryPermissionLevel } from '../../../prisma';
 import { typedKeys } from '../../utilities/objects';
 import type { AssignablePermissionGroups, TargetPermissionGroup, UserPermissionFlags } from '../interfaces';
 

--- a/src/lib/permissions/forums/policies/interfaces.ts
+++ b/src/lib/permissions/forums/policies/interfaces.ts
@@ -1,5 +1,4 @@
-import type { Post } from '@prisma/client';
-
+import type { Post } from '../../../../prisma';
 import type { PermissionFilteringPolicyFnInput } from '../../core/policies';
 import type { PostPermissionFlags } from '../interfaces';
 

--- a/src/lib/permissions/forums/policies/policyConvertedToProposal.ts
+++ b/src/lib/permissions/forums/policies/policyConvertedToProposal.ts
@@ -1,5 +1,4 @@
-import type { PostOperation } from '@prisma/client';
-
+import type { PostOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import type { PostPermissionFlags } from '../interfaces';
 

--- a/src/lib/permissions/hasAccessToSpace.ts
+++ b/src/lib/permissions/hasAccessToSpace.ts
@@ -1,5 +1,3 @@
-import type { SpaceRole } from '@prisma/client';
-
 import type { SystemError } from '../../lib/errors';
 import {
   InvalidInputError,
@@ -7,6 +5,7 @@ import {
   UserIsGuestError,
   UserIsNotSpaceMemberError
 } from '../../lib/errors';
+import type { SpaceRole } from '../../prisma';
 import { prisma } from '../../prisma-client';
 
 /**

--- a/src/lib/permissions/proposals/__tests__/mapProposalCategoryPermissionToAssignee.spec.ts
+++ b/src/lib/permissions/proposals/__tests__/mapProposalCategoryPermissionToAssignee.spec.ts
@@ -1,6 +1,6 @@
-import type { ProposalCategoryPermission } from '@prisma/client';
 import { v4 } from 'uuid';
 
+import type { ProposalCategoryPermission } from '../../../../prisma';
 import { InvalidPermissionGranteeError, ExpectedAnError } from '../../../errors';
 import type { AssignedProposalCategoryPermission } from '../interfaces';
 import { mapProposalCategoryPermissionToAssignee } from '../mapProposalCategoryPermissionToAssignee';

--- a/src/lib/permissions/proposals/availableProposalCategoryPermissions.class.ts
+++ b/src/lib/permissions/proposals/availableProposalCategoryPermissions.class.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategoryOperation } from '@prisma/client';
-
+import type { ProposalCategoryOperation } from '../../../prisma';
 import { BasePermissions } from '../core/basePermissions.class';
 
 import { proposalCategoryOperations } from './interfaces';

--- a/src/lib/permissions/proposals/availableProposalPermissions.class.ts
+++ b/src/lib/permissions/proposals/availableProposalPermissions.class.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../prisma';
 import { BasePermissions } from '../core/basePermissions.class';
 
 import { proposalOperations } from './interfaces';

--- a/src/lib/permissions/proposals/interfaces.ts
+++ b/src/lib/permissions/proposals/interfaces.ts
@@ -1,11 +1,10 @@
-import { ProposalCategoryOperation, ProposalOperation } from '@prisma/client';
+import { ProposalCategoryOperation, ProposalOperation } from '../../../prisma';
 import type {
   ProposalCategory,
   ProposalCategoryPermissionLevel,
   ProposalAuthor,
   ProposalReviewer
-} from '@prisma/client';
-
+} from '../../../prisma';
 import type { ProposalWithUsers } from '../../proposals/interfaces';
 import { typedKeys } from '../../utilities/objects';
 import type { AssignablePermissionGroups, TargetPermissionGroup, UserPermissionFlags } from '../interfaces';

--- a/src/lib/permissions/proposals/isProposalAuthor.ts
+++ b/src/lib/permissions/proposals/isProposalAuthor.ts
@@ -1,4 +1,4 @@
-import type { Proposal } from '@prisma/client';
+import type { Proposal } from '../../../prisma';
 
 import type { ProposalActors } from './interfaces';
 

--- a/src/lib/permissions/proposals/mapProposalCategoryPermissionToAssignee.ts
+++ b/src/lib/permissions/proposals/mapProposalCategoryPermissionToAssignee.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategoryPermission } from '@prisma/client';
-
+import type { ProposalCategoryPermission } from '../../../prisma';
 import { getPermissionAssignee } from '../core/getPermissionAssignee';
 import type { TargetPermissionGroup } from '../interfaces';
 

--- a/src/lib/permissions/proposals/policies/__tests__/policyStatusDiscussionEditableCommentable.spec.ts
+++ b/src/lib/permissions/proposals/policies/__tests__/policyStatusDiscussionEditableCommentable.spec.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategory, Space, User } from '@prisma/client';
-
+import type { ProposalCategory, Space, User } from '../../../../../prisma';
 import type { ProposalWithUsers } from '../../../../proposals/interfaces';
 import { generateProposal, generateProposalCategory } from '../../../../testing/proposals';
 import { generateSpaceUser, generateUserAndSpace } from '../../../../testing/user';

--- a/src/lib/permissions/proposals/policies/__tests__/policyStatusDraftNotViewable.spec.ts
+++ b/src/lib/permissions/proposals/policies/__tests__/policyStatusDraftNotViewable.spec.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategory, Space, User } from '@prisma/client';
-
+import type { ProposalCategory, Space, User } from '../../../../../prisma';
 import type { ProposalWithUsers } from '../../../../proposals/interfaces';
 import { generateProposal, generateProposalCategory } from '../../../../testing/proposals';
 import { generateSpaceUser, generateUserAndSpace } from '../../../../testing/user';

--- a/src/lib/permissions/proposals/policies/__tests__/policyStatusReviewCommentable.spec.ts
+++ b/src/lib/permissions/proposals/policies/__tests__/policyStatusReviewCommentable.spec.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategory, Space, User } from '@prisma/client';
-
+import type { ProposalCategory, Space, User } from '../../../../../prisma';
 import type { ProposalWithUsers } from '../../../../proposals/interfaces';
 import { generateProposal, generateProposalCategory } from '../../../../testing/proposals';
 import { generateSpaceUser, generateUserAndSpace } from '../../../../testing/user';

--- a/src/lib/permissions/proposals/policies/__tests__/policyStatusReviewedOnlyCreateVote.spec.ts
+++ b/src/lib/permissions/proposals/policies/__tests__/policyStatusReviewedOnlyCreateVote.spec.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategory, Space, User } from '@prisma/client';
-
+import type { ProposalCategory, Space, User } from '../../../../../prisma';
 import type { ProposalWithUsers } from '../../../../proposals/interfaces';
 import { generateProposal, generateProposalCategory } from '../../../../testing/proposals';
 import { generateSpaceUser, generateUserAndSpace } from '../../../../testing/user';

--- a/src/lib/permissions/proposals/policies/__tests__/policyStatusVoteActiveOnlyVotable.spec.ts
+++ b/src/lib/permissions/proposals/policies/__tests__/policyStatusVoteActiveOnlyVotable.spec.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategory, Space, User } from '@prisma/client';
-
+import type { ProposalCategory, Space, User } from '../../../../../prisma';
 import type { ProposalWithUsers } from '../../../../proposals/interfaces';
 import { generateProposal, generateProposalCategory } from '../../../../testing/proposals';
 import { generateSpaceUser, generateUserAndSpace } from '../../../../testing/user';

--- a/src/lib/permissions/proposals/policies/__tests__/policyStatusVoteClosedViewOnly.spec.ts
+++ b/src/lib/permissions/proposals/policies/__tests__/policyStatusVoteClosedViewOnly.spec.ts
@@ -1,5 +1,4 @@
-import type { ProposalCategory, Space, User } from '@prisma/client';
-
+import type { ProposalCategory, Space, User } from '../../../../../prisma';
 import type { ProposalWithUsers } from '../../../../proposals/interfaces';
 import { generateProposal, generateProposalCategory } from '../../../../testing/proposals';
 import { generateSpaceUser, generateUserAndSpace } from '../../../../testing/user';

--- a/src/lib/permissions/proposals/policies/policyStatusDiscussionEditableCommentable.ts
+++ b/src/lib/permissions/proposals/policies/policyStatusDiscussionEditableCommentable.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import { AvailableProposalPermissions } from '../availableProposalPermissions.class';
 import type { ProposalPermissionFlags } from '../interfaces';

--- a/src/lib/permissions/proposals/policies/policyStatusDraftNotViewable.ts
+++ b/src/lib/permissions/proposals/policies/policyStatusDraftNotViewable.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import { AvailableProposalPermissions } from '../availableProposalPermissions.class';
 import type { ProposalPermissionFlags } from '../interfaces';

--- a/src/lib/permissions/proposals/policies/policyStatusReviewCommentable.ts
+++ b/src/lib/permissions/proposals/policies/policyStatusReviewCommentable.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import { AvailableProposalPermissions } from '../availableProposalPermissions.class';
 import type { ProposalPermissionFlags } from '../interfaces';

--- a/src/lib/permissions/proposals/policies/policyStatusReviewedOnlyCreateVote.ts
+++ b/src/lib/permissions/proposals/policies/policyStatusReviewedOnlyCreateVote.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import { AvailableProposalPermissions } from '../availableProposalPermissions.class';
 import type { ProposalPermissionFlags } from '../interfaces';

--- a/src/lib/permissions/proposals/policies/policyStatusVoteActiveOnlyVotable.ts
+++ b/src/lib/permissions/proposals/policies/policyStatusVoteActiveOnlyVotable.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import type { ProposalPermissionFlags } from '../interfaces';
 import { isProposalAuthor } from '../isProposalAuthor';

--- a/src/lib/permissions/proposals/policies/policyStatusVoteClosedViewOnly.ts
+++ b/src/lib/permissions/proposals/policies/policyStatusVoteClosedViewOnly.ts
@@ -1,5 +1,4 @@
-import type { ProposalOperation } from '@prisma/client';
-
+import type { ProposalOperation } from '../../../../prisma';
 import { typedKeys } from '../../../utilities/objects';
 import type { ProposalPermissionFlags } from '../interfaces';
 import { isProposalAuthor } from '../isProposalAuthor';

--- a/src/lib/permissions/proposals/proposalFlowFlags.ts
+++ b/src/lib/permissions/proposals/proposalFlowFlags.ts
@@ -1,5 +1,4 @@
-import { ProposalStatus } from '@prisma/client';
-
+import { ProposalStatus } from '../../../prisma';
 import type { ProposalWithUsers } from '../../proposals/interfaces';
 import { typedKeys } from '../../utilities/objects';
 import { BasePermissions } from '../core/basePermissions.class';

--- a/src/lib/permissions/spaces/availableSpacePermissions.ts
+++ b/src/lib/permissions/spaces/availableSpacePermissions.ts
@@ -1,5 +1,4 @@
-import { SpaceOperation } from '@prisma/client';
-
+import { SpaceOperation } from '../../../prisma';
 import { BasePermissions } from '../core/basePermissions.class';
 
 export class AvailableSpacePermissions extends BasePermissions<SpaceOperation> {

--- a/src/lib/permissions/spaces/interfaces.ts
+++ b/src/lib/permissions/spaces/interfaces.ts
@@ -1,5 +1,4 @@
-import type { SpaceOperation } from '@prisma/client';
-
+import type { SpaceOperation } from '../../../prisma';
 import type { AssignablePermissionGroups, PermissionAssignment, UserPermissionFlags } from '../interfaces';
 
 export type SpacePermissionFlags = UserPermissionFlags<SpaceOperation>;

--- a/src/lib/proposals/interfaces.ts
+++ b/src/lib/proposals/interfaces.ts
@@ -1,5 +1,4 @@
-import type { Page, PageComment, Proposal, ProposalAuthor, ProposalReviewer } from '@prisma/client';
-
+import type { Page, PageComment, Proposal, ProposalAuthor, ProposalReviewer } from '../../prisma';
 import type { AssignablePermissionGroups } from '../permissions/interfaces';
 
 export interface ProposalReviewerInput {

--- a/src/lib/proposals/utils.ts
+++ b/src/lib/proposals/utils.ts
@@ -1,5 +1,4 @@
-import type { Prisma } from '@prisma/client';
-
+import type { Prisma } from '../../prisma';
 import { InvalidInputError } from '../errors';
 
 export function generateCategoryIdQuery(

--- a/src/lib/testing/forums.ts
+++ b/src/lib/testing/forums.ts
@@ -1,6 +1,6 @@
-import type { Post, PostCategory, PostComment, Prisma } from '@prisma/client';
 import { v4 } from 'uuid';
 
+import type { Post, PostCategory, PostComment, Prisma } from '../../prisma';
 import { prisma } from '../../prisma-client';
 import { stringToValidPath } from '../utilities/strings';
 

--- a/src/lib/testing/members.ts
+++ b/src/lib/testing/members.ts
@@ -1,6 +1,6 @@
-import type { Prisma, Role, RoleSource } from '@prisma/client';
 import { v4 } from 'uuid';
 
+import type { Prisma, Role, RoleSource } from '../../prisma';
 import { prisma } from '../../prisma-client';
 import { InvalidInputError } from '../errors';
 import { uniqueValues } from '../utilities/array';

--- a/src/lib/testing/pages.ts
+++ b/src/lib/testing/pages.ts
@@ -1,5 +1,4 @@
-import type { Page, Prisma, PrismaPromise } from '@prisma/client';
-
+import type { Page, Prisma, PrismaPromise } from '../../prisma';
 import { prisma } from '../../prisma-client';
 
 export function generatePage<T>({ data, include }: Prisma.PageCreateArgs): PrismaPromise<Page & T> {

--- a/src/lib/testing/proposals.ts
+++ b/src/lib/testing/proposals.ts
@@ -1,6 +1,6 @@
-import type { Page, Post, Prisma, ProposalCategory, ProposalStatus } from '@prisma/client';
 import { v4 } from 'uuid';
 
+import type { Page, Post, Prisma, ProposalCategory, ProposalStatus } from '../../prisma';
 import { prisma } from '../../prisma-client';
 import { randomThemeColor } from '../branding/colors';
 import { InvalidInputError } from '../errors';

--- a/src/lib/testing/spaces.ts
+++ b/src/lib/testing/spaces.ts
@@ -1,6 +1,5 @@
-import type { Prisma, SpacePermission } from '@prisma/client';
-import { SpaceOperation } from '@prisma/client';
-
+import type { Prisma, SpacePermission } from '../../prisma';
+import { SpaceOperation } from '../../prisma';
 import { prisma } from '../../prisma-client';
 import { InsecureOperationError, InvalidInputError, InvalidPermissionGranteeError } from '../errors';
 

--- a/src/lib/testing/user.ts
+++ b/src/lib/testing/user.ts
@@ -1,9 +1,9 @@
-import type { SubscriptionTier, User } from '@prisma/client';
 import { v4 } from 'uuid';
 
 import { sessionUserRelations } from '../../lib/session/config';
 import type { LoggedInUser } from '../../lib/user/interfaces';
 import { uid } from '../../lib/utilities/strings';
+import type { SubscriptionTier, User } from '../../prisma';
 import { prisma } from '../../prisma-client';
 
 import { randomETHWalletAddress } from './random';

--- a/src/lib/user/interfaces.ts
+++ b/src/lib/user/interfaces.ts
@@ -10,7 +10,7 @@ import type {
   UserNotificationState,
   SpaceRoleToRole,
   Role
-} from '@prisma/client';
+} from '../../prisma';
 
 interface NestedMemberships {
   spaceRoleToRole: (SpaceRoleToRole & { role: Role })[];

--- a/src/lib/utilities/strings.ts
+++ b/src/lib/utilities/strings.ts
@@ -1,8 +1,9 @@
-import type { UserWallet } from '@prisma/client';
 import { isAddress } from 'ethers';
 import { customAlphabet } from 'nanoid';
 import * as dictionaries from 'nanoid-dictionary';
 import { validate } from 'uuid';
+
+import type { UserWallet } from '../../prisma';
 
 export function fancyTrim(_text: string = '', maxLength: number = 40) {
   const text = _text || '';

--- a/src/prisma-client.ts
+++ b/src/prisma-client.ts
@@ -1,7 +1,7 @@
-import type { Prisma } from '@prisma/client';
-import { PrismaClient } from '@prisma/client';
+import type { Prisma } from './prisma';
+import { PrismaClient } from './prisma';
 
-export * from '@prisma/client';
+export * from './prisma';
 
 // @ts-ignore - add support for JSON for BigInt (used in telegramuser) - https://github.com/GoogleChromeLabs/jsbi/issues/30
 // eslint-disable-next-line no-extend-native

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,1 +1,2 @@
-export * from '@prisma/client';
+// eslint-disable-next-line import/no-relative-packages
+export * from './prisma/client/index';

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -2,6 +2,7 @@ generator client {
   provider        = "prisma-client-js"
   binaryTargets   = ["debian-openssl-1.1.x", "linux-musl", "darwin", "native"]
   previewFeatures = ["fullTextSearch", "extendedWhereUnique"]
+  output          = "./client"
 }
 
 datasource db {
@@ -843,7 +844,7 @@ model UserGnosisSafe {
   chainId   Int
   address   String
   name      String?
-  isHidden    Boolean  @default(false)
+  isHidden  Boolean  @default(false)
   threshold Int
   owners    String[]
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Having the output live inside node_modules doesn't work when you are using a monorepo/npm link-type setup. 
Some related issues: https://github.com/prisma/prisma/issues/17687