### PR TITLE
Remove requireProposalTemplate from SpaceOperation

### DIFF
--- a/src/prisma/migrations/20230606145823_require_proposal_template/migration.sql
+++ b/src/prisma/migrations/20230606145823_require_proposal_template/migration.sql
@@ -1,5 +1,2 @@
--- AlterEnum
-ALTER TYPE "SpaceOperation" ADD VALUE 'requireProposalTemplate';
-
 -- AlterTable
 ALTER TABLE "Space" ADD COLUMN     "requireProposalTemplate" BOOLEAN DEFAULT false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -136,7 +136,6 @@ enum SpaceOperation {
   createForumCategory
   moderateForums
   reviewProposals
-  requireProposalTemplate
 }
 
 enum ProfileItemType {


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Remove unneeded field on SpaceOperations as it is already on the space