### PR TITLE
version bump change

### DIFF
--- a/.github/actions/package_n_publish/action.yml
+++ b/.github/actions/package_n_publish/action.yml
@@ -8,8 +8,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-
     - uses: actions/setup-node@v3
       with:
         node-version: 18
@@ -29,6 +27,8 @@ runs:
         major-wording:  'MAJOR,major,breaking,'
         minor-wording:  'add,Adds,new,feat'
         patch-wording:  'patch,fixes,fix'
+        bump-policy: 'last-commit'
+        commit-message: 'CI: bumps version to {{version}} in workflow ${{ github.run_id }}'
 
     - name: Write Version for package of pull request branch 
       if: github.event_name == 'pull_request' && ( github.event.action == 'opened' || github.event.action == 'synchronize' )
@@ -39,6 +39,7 @@ runs:
       with:
         version-type: prerelease
         preid: 'rc-${{ env.GITHUB_HEAD_REF }}'
+        bump-policy: 'ignore'
 
     - name: Publish package
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,8 @@ jobs:
         #   Then the following bumping version step will not run
         #   as the bump-policy is only checking against that last commit.
       - uses: actions/checkout@v3
-        fetch-depth: 2
+        with:
+          fetch-depth: 2
       - run: git checkout HEAD
       - name: package and publish release candidate pkg
         id: publish_release_pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,14 @@ jobs:
           #   repo: "permissions.charmverse.io"
           #   pkg_test_workflow: "test_and_deploy.yml"
     steps:
+        # assuming that there was a previous workflow run that had changed the version
+        #   then failed in substeps.  In a workflow/job rerun, the special checkout 
+        #   procedure will advance the code to include that last commit.
+        #   Then the following bumping version step will not run
+        #   as the bump-policy is only checking against that last commit.
       - uses: actions/checkout@v3
+        fetch-depth: 2
+      - run: git checkout HEAD
       - name: package and publish release candidate pkg
         id: publish_release_pkg
         uses: ./.github/actions/package_n_publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "1.0.11",
+  "version": "1.0.12-rc-making-pushpkg-workflow-rerunnable.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
on Main branch on workflow re-run it will pull the latest code before version bumping

### WHAT
copilot:summary

### WHY
When code is pushed to main, pkg pushed, and downstream trigger workflow failed, subsequent rerun will generate errors with outdated branch as the version has already been bumped. This PR addresses that issue and will only bump version when previous commit isn't a bump
