### PR TITLE
now passing workflow_payload to permissions api trigger

### DIFF
--- a/.github/actions/package_n_publish/action.yml
+++ b/.github/actions/package_n_publish/action.yml
@@ -38,7 +38,7 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       with:
         version-type: prerelease
-        default: prerelease
+        patch-wording:  'patch,fixes,fix'
         preid: 'rc-${{ env.GITHUB_HEAD_REF }}'
         bump-policy: 'ignore'
 

--- a/.github/actions/package_n_publish/action.yml
+++ b/.github/actions/package_n_publish/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Write Version for package of main branch
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: version_main
-      uses:  'phips28/gh-action-bump-version@master'
+      uses:  'phips28/gh-action-bump-version@v10.0.0'
       env:
         GITHUB_TOKEN: ${{ env.WORKFLOW_TRIGGER_PAT }}
       with:
@@ -33,12 +33,11 @@ runs:
     - name: Write Version for package of pull request branch 
       if: github.event_name == 'pull_request' && ( github.event.action == 'opened' || github.event.action == 'synchronize' )
       id: version_other_branch
-      uses:  'phips28/gh-action-bump-version@master'
+      uses:  'phips28/gh-action-bump-version@v10.0.0'
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       with:
         version-type: prerelease
-        patch-wording:  'patch,fixes,fix'
         preid: 'rc-${{ env.GITHUB_HEAD_REF }}'
         bump-policy: 'ignore'
 

--- a/.github/actions/package_n_publish/action.yml
+++ b/.github/actions/package_n_publish/action.yml
@@ -38,6 +38,7 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       with:
         version-type: prerelease
+        default: prerelease
         preid: 'rc-${{ env.GITHUB_HEAD_REF }}'
         bump-policy: 'ignore'
 

--- a/.github/actions/package_n_publish/action.yml
+++ b/.github/actions/package_n_publish/action.yml
@@ -38,6 +38,10 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       with:
         version-type: prerelease
+        default: prerelease
+        major-wording:  'MAJOR,major,breaking,'
+        minor-wording:  'add,Adds,new,feat'
+        patch-wording:  'patch,fixes,fix'
         preid: 'rc-${{ env.GITHUB_HEAD_REF }}'
         bump-policy: 'ignore'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,24 +66,27 @@ jobs:
         include:
           - test_name: "Testing with Webapp"
             repo: "app.charmverse.io"
-            pkg_test_workflow: "test_and_deploy.yml"
-          - test_name: "Testing with Permission API"
-            repo: "permissions.charmverse.io"
-            pkg_test_workflow: "test_and_deploy.yml"
+            workflow_file: "test_and_deploy.yml"
+            workflow_payload: |
+              { "core_pkg_version": "${{ needs.push-rc-package.outputs.pkg_version }}", 
+              "run_e2e_browser_test": false, 
+              "deploy_to_prd": false }
+          - repo: "permissions.charmverse.io"
+            workflow_file: "test_and_deploy.yml"
+            workflow_payload: |
+              { "core_pkg_version": "${{ needs.push-rc-package.outputs.pkg_version }}", 
+              "deploy_to_prd": false }
     steps:
-      - name: Trigger test workflow - ${{matrix.test_name}}
+      - name: Trigger tests on repo ${{ matrix.repo }}
         uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
           owner: charmverse
-          repo: ${{matrix.repo}}
+          repo: ${{ matrix.repo }}
           github_token: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
           github_user: yiwork
-          workflow_file_name: ${{matrix.pkg_test_workflow}}
+          workflow_file_name: ${{ matrix.workflow_file }}
           ref: main
-          client_payload: |
-            { "core_pkg_version": "${{ needs.push-rc-package.outputs.pkg_version }}", 
-              "run_e2e_browser_test": false, 
-              "deploy_to_prd": false }
+          client_payload: ${{ matrix.workflow_payload }}
           wait_interval: 10
           propagate_failure: true
           trigger_workflow: true
@@ -139,12 +142,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_name: "Update Core on Webapp and Deploy"
-            repo: "app.charmverse.io"
-            pkg_test_workflow: "test_and_deploy.yml"
-          # - test_name: "Update Core on Permissions API and Deploy"
-          #   repo: "permissions.charmverse.io"
-          #   pkg_test_workflow: "test_and_deploy.yml"
+          - repo: "app.charmverse.io"
+            workflow_file: "test_and_deploy.yml"
+            workflow_payload: |
+              { "core_pkg_version": "${{ needs.publish_release_pkg.outputs.pkg_version }}", 
+              "run_e2e_browser_test": true, 
+              "deploy_to_prd": true }
+          - repo: "permissions.charmverse.io"
+            workflow_file: "test_and_deploy.yml"
+            workflow_payload: |
+              { "core_pkg_version": "${{ needs.push-rc-package.outputs.pkg_version }}", 
+              "deploy_to_prd": true }
     steps:
         # assuming that there was a previous workflow run that had changed the version
         #   then failed in substeps.  In a workflow/job rerun, the special checkout 
@@ -162,19 +170,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           WORKFLOW_TRIGGER_PAT: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
-      - name: Trigger Core pkg update
+      - name: Trigger Core pkg update and deploy on repo ${{ matrix.repo }}
         uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
           owner: charmverse
-          repo: app.charmverse.io
+          repo: ${{ matrix.repo }}
           github_token: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
           github_user: yiwork
-          workflow_file_name: test_and_deploy.yml
+          workflow_file_name: ${{ matrix.workflow_file }}
           ref: main
-          client_payload: |
-              { "core_pkg_version": "${{ steps.publish_release_pkg.outputs.pkg_version }}", 
-                "run_e2e_browser_test": true, 
-                "deploy_to_prd": true }
+          client_payload: ${{ matrix.workflow_payload }}
           wait_interval: 10
           propagate_failure: true
           trigger_workflow: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "1.0.12-rc-making-pushpkg-workflow-rerunnable.0",
+  "version": "1.0.13-rc-fixing-triggering-permission-api-workflow.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
modified the matrix test and deploy triggers to better accommodate the differing repos and workflow inputs. 

### WHAT
copilot:summary

### WHY
permissions api workflow has different input than webapp workflow. 
