### PR TITLE
add new 'community' tier to enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.1.3-rc-replace-tier-na.0",
+  "version": "0.1.3-rc-replace-tier-na.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.1.3-rc-replace-tier-na.1",
+  "version": "0.1.3-rc-replace-tier-na.2",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.1.2",
+  "version": "0.1.3-rc-replace-tier-na.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/testing/__tests__/user.spec.ts
+++ b/src/lib/testing/__tests__/user.spec.ts
@@ -9,7 +9,7 @@ describe('generateUserAndSpace', () => {
 
     expect(space.publicBountyBoard).toBe(false);
     expect(space.publicProposals).toBe(false);
-    expect(space.paidTier).toBe('pro');
+    expect(space.paidTier).toBe('community');
 
     const spaceRole = (await prisma.spaceRole.findFirst({
       where: {

--- a/src/lib/testing/user.ts
+++ b/src/lib/testing/user.ts
@@ -62,7 +62,7 @@ export async function generateUserAndSpace({
   spaceName = 'Example Space',
   publicBountyBoard = false,
   publicProposals = false,
-  spacePaidTier = 'pro'
+  spacePaidTier = 'community'
 }: CreateUserAndSpaceInput = {}) {
   const userId = v4();
   const newUser = await prisma.user.create({

--- a/src/prisma/migrations/20230718220322_add_paid_tier_community/migration.sql
+++ b/src/prisma/migrations/20230718220322_add_paid_tier_community/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SubscriptionTier" ADD VALUE 'community';

--- a/src/prisma/migrations/20230718220451_default_paid_tier/migration.sql
+++ b/src/prisma/migrations/20230718220451_default_paid_tier/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Space" ALTER COLUMN "paidTier" SET DEFAULT 'community';

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -236,7 +236,7 @@ enum ApiPageKeyType {
 
 enum SubscriptionTier {
   free
-  pro
+  community
   enterprise
   cancelled
 }
@@ -258,7 +258,7 @@ model Space {
   customDomain                String?                           @unique
   isCustomDomainVerified      Boolean?
   notifyNewProposals          DateTime?                         @default(now())
-  paidTier                    SubscriptionTier                  @default(pro)
+  paidTier                    SubscriptionTier                  @default(community)
   discordServerId             String?
   defaultVotingDuration       Int?
   snapshotDomain              String?
@@ -1071,7 +1071,7 @@ model Proposal {
   createdBy              String             @db.Uuid
   spaceId                String             @db.Uuid
   status                 ProposalStatus
-  archived               Boolean?            @default(false)
+  archived               Boolean?           @default(false)
   authors                ProposalAuthor[]
   reviewers              ProposalReviewer[]
   space                  Space              @relation(fields: [spaceId], references: [id], onDelete: Cascade)

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -236,6 +236,7 @@ enum ApiPageKeyType {
 
 enum SubscriptionTier {
   free
+  pro
   community
   enterprise
   cancelled
@@ -258,7 +259,7 @@ model Space {
   customDomain                String?                           @unique
   isCustomDomainVerified      Boolean?
   notifyNewProposals          DateTime?                         @default(now())
-  paidTier                    SubscriptionTier                  @default(community)
+  paidTier                    SubscriptionTier                  @default(pro)
   discordServerId             String?
   defaultVotingDuration       Int?
   snapshotDomain              String?

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -259,7 +259,7 @@ model Space {
   customDomain                String?                           @unique
   isCustomDomainVerified      Boolean?
   notifyNewProposals          DateTime?                         @default(now())
-  paidTier                    SubscriptionTier                  @default(pro)
+  paidTier                    SubscriptionTier                  @default(community)
   discordServerId             String?
   defaultVotingDuration       Int?
   snapshotDomain              String?


### PR DESCRIPTION
I plan on doing this in two steps:
1) add 'community' as a new default and update app.charmverse to support both values
2) migrate all spaces to 'community' and then remove 'pro' from the enum