### PR TITLE
enable 2 separate ways of triggering test workflow

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -17,9 +17,11 @@ runs:
       uses: actions/cache@v3
       with:
         path: ./node_modules
-        key: nodemodules-cache-${{ hashFiles('package.json') }}-${{ hashFiles('patches/**.patch', 'src/prisma/schema.prisma') }}
+        key: core-depcache-${{ hashFiles('package.json') }}-${{ hashFiles('patches/**.patch', 'src/prisma/schema.prisma') }}
 
     - name: Install npm dependencies
       shell: bash
       if: steps.cache_node_modules.outputs.cache-hit != 'true'
-      run: npm i --no-audit --no-fund
+      run: |
+        npm i --no-audit --no-fund
+        echo "workflow ref: ${{github.workflow_ref}}"

--- a/.github/actions/package_n_publish/action.yml
+++ b/.github/actions/package_n_publish/action.yml
@@ -27,7 +27,7 @@ runs:
       with:
         default: patch
         major-wording:  'MAJOR,major,breaking,'
-        minor-wording:  'add,Adds,new,feat'
+        minor-wording:  'feat,feature,upgrade'
         patch-wording:  'patch,fixes,fix'
         bump-policy: 'last-commit'
         commit-message: 'CI: bumps version to {{version}} in workflow ${{ github.run_id }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
               { "core_pkg_version": "${{ needs.push-package.outputs.pkg_version }}" }
     steps:
       - name: Trigger tests on repo ${{ matrix.repo }}
-        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: charmverse
           repo: ${{ matrix.repo }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,17 @@ on:
   workflow_dispatch:
     inputs:
       webapp_branch:
-        description: 'Webapp branch to test against, defaults to main'
+        description: 'Webapp branch to test against.'
         required: true
-        default: 'main'
-      permissions_branch:
-        description: 'Permissionsi api branch to test against, defaults to main'
+      permissionapi_branch:
+        description: 'Permissions api branch to test against'
         required: true
-        default: 'main'
+
+# Change the below to get your PR CI to run tests against a specific branch
+#   Overrides the input, as inputs always have a default value
+env:
+  WEBAPP_WORKFLOW_BRANCH:
+  PERMISSION_WORKFLOW_BRANCH:
 
 jobs:
   build-test-env:
@@ -61,7 +65,30 @@ jobs:
       pull-requests: write
     outputs:
       pkg_version: ${{ steps.publish_pkg.outputs.pkg_version }}
+      webapp_workflow_branch: ${{ steps.set_downstream_repo_branch.outputs.webapp_workflow_branch }}
+      permissionapi_workflow_branch: ${{ steps.set_downstream_repo_branch.outputs.permissionapi_workflow_branch }}
     steps:
+      - name: Determine downstream repo branch to run tests against first
+        id: set_downstream_repo_branch
+        run: |
+          if [[ ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/heads/main' ]]; then
+            echo "webapp_workflow_branch='main'" >> $GITHUB_OUTPUT
+            echo "permissionapi_workflow_branch='main'" >> $GITHUB_OUTPUT
+
+          elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            echo "webapp_workflow_branch=${{inputs.webapp_branch}}" >> $GITHUB_OUTPUT
+            echo "permissionapi_workflow_branch=${{inputs.permissionapi_branch}}" >> $GITHUB_OUTPUT
+          else
+            if [[ $WEBAPP_WORKFLOW_BRANCH != ${{ github.head_ref }} || $PERMISSION_WORKFLOW_BRANCH != ${{ github.head_ref }} ]]; then 
+              echo "Workflow branch env vars is not this current branch. Are you sure they are set correctly?"
+              echo "PR head branch: $GITHUB_HEAD_REF_SLUG"
+              echo "env WEBAPP_WORKFLOW_BRANCH: $WEBAPP_WORKFLOW_BRANCH"
+              echo "env PERMISSION_WORKFLOW_BRANCH: $PERMISSION_WORKFLOW_BRANCH"
+              exit 1
+            fi
+            echo "webapp_workflow_branch=$WEBAPP_WORKFLOW_BRANCH" >> $GITHUB_OUTPUT
+            echo "permissionapi_workflow_branch=$PERMISSION_WORKFLOW_BRANCH" >> $GITHUB_OUTPUT
+          fi
       # On rerun - upstream would've changed with a version update. 
       #   So checking out with the head of Pull request Merge 
       - uses: actions/checkout@v3
@@ -72,6 +99,7 @@ jobs:
         if: github.run_attempt == 1
       - run: |
           cat package.json
+          echo "run attempt ${{github.run_attempt}}"
       - name: Restore build cache
         uses: ./.github/actions/build
       - name: Package and publish release candidate pkg
@@ -88,7 +116,7 @@ jobs:
             Code ${{ github.sha }} labeled version ${{ steps.publish_pkg.outputs.pkg_version }}
 
   run-downstream-test-workflows:
-    if: github.event_name == 'pull_request' && ( github.event.action == 'opened' || github.event.action == 'synchronize' )
+    if: github.event_name != 'push' && github.ref != 'refs/heads/main'
     name: Trigger ${{matrix.repo}} testing workflow
     runs-on: ubuntu-latest
     needs: push-package
@@ -97,14 +125,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_name: "Testing with Webapp"
-            repo: "app.charmverse.io"
-            branch: ${{ inputs.webapp_branch }}
+          - repo: "app.charmverse.io"
+            branch: "${{ needs.push-package.outputs.webapp_workflow_branch }}"
             workflow_file: "test_new_core_pkg.yml"
             workflow_payload: |
               { "core_pkg_version": "${{ needs.push-package.outputs.pkg_version }}" }
           - repo: "permissions.charmverse.io"
-            branch: ${{ inputs.permissions_branch }}
+            branch: "${{ needs.push-package.outputs.permissionapi_workflow_branch }}"
             workflow_file: "test_core_pkg.yml"
             workflow_payload: |
               { "core_pkg_version": "${{ needs.push-package.outputs.pkg_version }}" }
@@ -193,7 +220,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
           github_user: charmed-bot
           workflow_file_name: ${{ matrix.workflow_file }}
-          ref: main
+          ref: 'main'
           client_payload: ${{ matrix.workflow_payload }}
           wait_interval: 10
           propagate_failure: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: typecheck
     permissions:
-      contents: write
       pull-requests: write
     outputs:
       pkg_version: ${{ steps.publish_pkg.outputs.pkg_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: typecheck
     permissions:
+      contents: write
       pull-requests: write
     outputs:
       pkg_version: ${{ steps.publish_pkg.outputs.pkg_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,11 +94,13 @@ jobs:
           fi
       # On rerun - upstream would've changed with a version update. 
       #   So checking out with the head of Pull request Merge 
-      - uses: actions/checkout@v3
+      - name: Checkout head of merge on re-run
+        uses: actions/checkout@v3
         if: github.run_attempt > 1
         with:   
           ref: refs/pull/${{ github.event.number }}/merge
-      - uses: actions/checkout@v3
+      - name: Checkout ref of the event that triggered this workflow. (first time run)
+        uses: actions/checkout@v3 
         if: github.run_attempt == 1
       - run: |
           cat package.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,21 +40,15 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     needs: build-test-env
-    strategy:
-      max-parallel: 5
-      fail-fast: false
-      matrix:
-        include:
-          - test_name: "Type check"
-            test_command: "npm run typecheck"
     steps:
       - uses: actions/checkout@v3
 
       - name: Restore dependencies from cache
         uses: ./.github/actions/install
 
-      - name: Run ${{matrix.test_name}}
-        run: ${{matrix.test_command}}
+      - name: Run type check
+        run: |
+          npm run typecheck
 
   push-package:
     name: Push Release candidate package to allow devs to use to test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,7 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
+          comment_downstream_url: true
 
   integration-test:
     name: Run Integration Tests
@@ -220,7 +221,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TRIGGER_PAT }}
           github_user: charmed-bot
           workflow_file_name: ${{ matrix.workflow_file }}
-          ref: 'main'
+          ref: "main"
           client_payload: ${{ matrix.workflow_payload }}
           wait_interval: 10
           propagate_failure: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,7 @@ jobs:
     needs: push-package
     permissions:
       contents: write
+      pull-requests: write
     strategy:
       max-parallel: 2
       fail-fast: false
@@ -162,7 +163,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
           comment_downstream_url: ${{ github.event.pull_request.comments_url }}
-          comment_github_token: ${{github.token}}
+#          comment_github_token: ${{github.token}}
 
   integration-test:
     name: Run Integration Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
           comment_downstream_url: ${{ github.event.pull_request.comments_url }}
+          comment_github_token: ${{github.token}}
 
   integration-test:
     name: Run Integration Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,8 @@ jobs:
     name: Trigger ${{matrix.repo}} testing workflow
     runs-on: ubuntu-latest
     needs: push-package
+    permissions:
+      contents: write
     strategy:
       max-parallel: 2
       fail-fast: false
@@ -159,7 +161,7 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-          comment_downstream_url: true
+          comment_downstream_url: ${{ github.event.pull_request.comments_url }}
 
   integration-test:
     name: Run Integration Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
             fi
             echo "webapp_workflow_branch=$WEBAPP_WORKFLOW_BRANCH" >> $GITHUB_OUTPUT
             echo "permissionapi_workflow_branch=$PERMISSION_WORKFLOW_BRANCH" >> $GITHUB_OUTPUT
+          fi
       # On rerun - upstream would've changed with a version update. 
       #   So checking out with the head of Pull request Merge 
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Determine downstream repo branch to run tests against first
         id: set_downstream_repo_branch
         run: |
+          # values of this step's output is used in step run-downstream-test-workflows
+          # strategy/matrix doesn't permit access to env context. very lame...
+
           if [[ ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/heads/main' ]]; then
             echo "webapp_workflow_branch='main'" >> $GITHUB_OUTPUT
             echo "permissionapi_workflow_branch='main'" >> $GITHUB_OUTPUT
@@ -79,16 +82,21 @@ jobs:
             echo "webapp_workflow_branch=${{inputs.webapp_branch}}" >> $GITHUB_OUTPUT
             echo "permissionapi_workflow_branch=${{inputs.permissionapi_branch}}" >> $GITHUB_OUTPUT
           else
-            if [[ $WEBAPP_WORKFLOW_BRANCH != ${{ github.head_ref }} || $PERMISSION_WORKFLOW_BRANCH != ${{ github.head_ref }} ]]; then 
-              echo "Workflow branch env vars is not this current branch. Are you sure they are set correctly?"
-              echo "PR head branch: $GITHUB_HEAD_REF_SLUG"
-              echo "env WEBAPP_WORKFLOW_BRANCH: $WEBAPP_WORKFLOW_BRANCH"
-              echo "env PERMISSION_WORKFLOW_BRANCH: $PERMISSION_WORKFLOW_BRANCH"
-              exit 1
+            if [[ -z $WEBAPP_WORKFLOW_BRANCH || -z $PERMISSION_WORKFLOW_BRANCH ]]; then
+              echo "::notice title=Test branch target::Setting downstream repo test to test against branch main."
+              WEBAPP_WORKFLOW_BRANCH='main'
+              PERMISSION_WORKFLOW_BRANCH='main'
+            else 
+              if [[ $WEBAPP_WORKFLOW_BRANCH != ${{ github.head_ref }} || $PERMISSION_WORKFLOW_BRANCH != ${{ github.head_ref }} ]]; then
+                echo "::warning title=Mismatch in test branch target::Workflow branch env vars is not this current branch. Are you sure they are set correctly??"
+                echo "Setting downstream repo branch to what is set in env."
+                echo "PR head branch: $GITHUB_HEAD_REF_SLUG"
+                echo "env WEBAPP_WORKFLOW_BRANCH: $WEBAPP_WORKFLOW_BRANCH"
+                echo "env PERMISSION_WORKFLOW_BRANCH: $PERMISSION_WORKFLOW_BRANCH"
+              fi
             fi
             echo "webapp_workflow_branch=$WEBAPP_WORKFLOW_BRANCH" >> $GITHUB_OUTPUT
             echo "permissionapi_workflow_branch=$PERMISSION_WORKFLOW_BRANCH" >> $GITHUB_OUTPUT
-          fi
       # On rerun - upstream would've changed with a version update. 
       #   So checking out with the head of Pull request Merge 
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: push-package
     permissions:
-      contents: write
       pull-requests: write
     strategy:
       max-parallel: 2
@@ -163,7 +162,6 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
           comment_downstream_url: ${{ github.event.pull_request.comments_url }}
-#          comment_github_token: ${{github.token}}
 
   integration-test:
     name: Run Integration Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.7",
+  "version": "0.2.2-rc-paramatizing-do.8",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.0",
+  "version": "0.2.2-rc-paramatizing-do.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.4",
+  "version": "0.2.2-rc-paramatizing-do.5",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.5",
+  "version": "0.2.2-rc-paramatizing-do.6",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.3",
+  "version": "0.2.2-rc-paramatizing-do.4",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.0",
+  "version": "0.2.2-rc-paramatizing-do.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.2",
+  "version": "0.2.2-rc-paramatizing-do.3",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.6",
+  "version": "0.2.2-rc-paramatizing-do.7",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.2.2-rc-paramatizing-do.1",
+  "version": "0.2.2-rc-paramatizing-do.2",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
Enable 2 separate ways of triggering test workflow with specific downstream repo branches. 1. from PR by setting env variable. 2. from web gui (need another input for this feature to work)

### WHAT
copilot:summary

### WHY
Sometimes it might be faster to trigger tests in downstream repos with custom branches via PR. Now they can do this. This also enabled GUI trigger though it isn't properly tested at the moment
