### PR TITLE
add meta column to user space action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.3.26-rc-meta-column.0",
+  "version": "0.3.26-rc-meta-column.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.3.25",
+  "version": "0.3.26-rc-meta-column.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20230911173959_add_user_action_meta_column/migration.sql
+++ b/src/prisma/migrations/20230911173959_add_user_action_meta_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserSpaceAction" ADD COLUMN     "meta" JSONB;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -414,6 +414,8 @@ model Page {
   userSpaceActions    UserSpaceAction[]
   sourceTemplateId    String?           @db.Uuid
 
+  // Ensure synced proposal databases cannot have duplicate cards for a proposal
+  @@unique([parentId, syncWithPageId])
   @@index([bountyId])
   @@index([cardId])
   @@index([createdBy])
@@ -422,20 +424,19 @@ model Page {
   @@index([proposalId])
   @@index([spaceId])
   @@index([title])
-  // Ensure synced proposal databases cannot have duplicate cards for a proposal
-  @@unique([parentId, syncWithPageId])
 }
 
 model UserSpaceAction {
   id             String              @id @default(uuid()) @db.Uuid
   createdAt      DateTime            @default(now())
   createdBy      String?             @db.Uuid
-  distinctUserId String?              @db.Uuid
+  distinctUserId String?             @db.Uuid
   pageId         String?             @db.Uuid
   page           Page?               @relation(fields: [pageId], references: [id], onDelete: Cascade)
   postId         String?             @db.Uuid
   post           Post?               @relation(fields: [postId], references: [id], onDelete: Cascade)
   action         UserSpaceActionType
+  meta           Json?
   pageType       String?
   user           User?               @relation(fields: [createdBy], references: [id], onDelete: Cascade)
   spaceId        String?             @db.Uuid
@@ -1137,7 +1138,7 @@ model ProposalBlock {
   parentId  String
   rootId    String    @db.Uuid
   schema    Int
-  type      String            @default("board")
+  type      String    @default("board")
   title     String
   fields    Json
   user      User      @relation(fields: [createdBy], references: [id])


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
We need to keep track of the view a user is looking at on a database. I also want to keep track of whether it's in a card view or not, in which case we would load the database page. This table has many many rows since it tracks page views, so rather than add two new columns for 'viewId' and 'parentId' (?), I think a meta blob is fine.
