### PR TITLE
Add base permissions compute to permissions api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.3.35",
+  "version": "0.3.36-rc-extend-premium.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/permissions/proposals/client/interfaces.ts
+++ b/src/lib/permissions/proposals/client/interfaces.ts
@@ -25,6 +25,7 @@ export type BaseProposalPermissionsClient = {
 };
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type PremiumProposalPermissionsClient = BaseProposalPermissionsClient & {
+  computeBaseProposalPermissions: (request: PermissionCompute) => Promise<ProposalPermissionFlags>;
   assignDefaultProposalCategoryPermissions: (proposalCategory: Resource) => Promise<void>;
   upsertProposalCategoryPermission: (
     assignment: ProposalCategoryPermissionAssignment

--- a/src/lib/permissions/proposals/client/proposalPermissionsHttpClient.ts
+++ b/src/lib/permissions/proposals/client/proposalPermissionsHttpClient.ts
@@ -52,6 +52,10 @@ export class ProposalPermissionsHttpClient
     return GET(`${this.prefix}/compute-proposal-permissions`, request);
   }
 
+  computeBaseProposalPermissions(request: PermissionCompute): Promise<ProposalPermissionFlags> {
+    return GET(`${this.prefix}/compute-base-proposal-permissions`, request);
+  }
+
   computeProposalFlowPermissions(request: PermissionCompute): Promise<ProposalFlowPermissionFlags> {
     return GET(`${this.prefix}/compute-proposal-flow-permissions`, request);
   }


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Add a premium method for getting base computed permissions. We don't need this in free tier for now
