### PR TITLE
Extend testing generators

### DIFF
--- a/src/lib/testing/__tests__/proposals.spec.ts
+++ b/src/lib/testing/__tests__/proposals.spec.ts
@@ -29,6 +29,11 @@ describe('generateProposal', () => {
       title: 'Proposal title for testing'
     };
 
+    const customProperties = {
+      first: 1,
+      second: 2
+    };
+
     const proposalInput: GenerateProposalInput = {
       spaceId: space.id,
       userId: user.id,
@@ -36,7 +41,8 @@ describe('generateProposal', () => {
       proposalStatus: 'review',
       reviewers: [{ group: 'role', id: role.id }],
       categoryId: proposalCategory.id,
-      archived: true
+      archived: true,
+      customProperties
     };
 
     const generatedProposal = await generateProposal({
@@ -62,6 +68,9 @@ describe('generateProposal', () => {
       category: proposalCategory,
       page: expect.any(Object),
       evaluationType: 'vote',
+      fields: {
+        properties: customProperties
+      },
       authors: expect.arrayContaining([
         {
           proposalId: generatedProposal.id,
@@ -79,8 +88,7 @@ describe('generateProposal', () => {
           roleId: role.id,
           userId: null
         }
-      ],
-      fields: null
+      ]
     });
 
     const proposalPageFromDb = (await prisma.page.findUnique({

--- a/src/lib/testing/proposals.ts
+++ b/src/lib/testing/proposals.ts
@@ -56,6 +56,7 @@ export type GenerateProposalInput = {
   title?: string;
   content?: any;
   evaluationType?: ProposalEvaluationType;
+  customProperties?: Record<string, any>;
 };
 
 /**
@@ -72,7 +73,8 @@ export async function generateProposal({
   deletedAt = null,
   content,
   archived,
-  evaluationType
+  evaluationType,
+  customProperties
 }: GenerateProposalInput): Promise<ProposalWithUsers & { page: Page }> {
   const proposalId = v4();
 
@@ -91,6 +93,11 @@ export async function generateProposal({
           id: spaceId
         }
       },
+      fields: customProperties
+        ? {
+            properties: customProperties
+          }
+        : undefined,
       authors: !authors.length
         ? undefined
         : {


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Extend test generators to support proposal blocks