### PR TITLE
Allow admins and reviewers to revert evaluation_closed to evaluation_active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.5.8",
+  "version": "0.6.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.6.2",
+  "version": "0.9.3-rc-permissions-rev.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.9.3-rc-permissions-rev.3",
+  "version": "0.9.3-rc-permissions-rev.4",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.5.8-rc-billing-extend.1",
+  "version": "0.5.8",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/permissions/proposals/__tests__/proposalFlowFlags.spec.ts
+++ b/src/lib/permissions/proposals/__tests__/proposalFlowFlags.spec.ts
@@ -123,7 +123,7 @@ describe('getProposalFlagFilters', () => {
     expect(memberFlags).toMatchObject(new TransitionFlags().empty);
   });
 
-  it('should allow draft and review state for discussion proposals if user is author or admin', async () => {
+  it('should allow draft for discussion proposals if user is author or admin, and review if user is author, admin or reviewer', async () => {
     const proposalStatus: ProposalStatus = 'discussion';
 
     const getFlags = proposalFlowFlagFilters[proposalStatus];
@@ -145,13 +145,13 @@ describe('getProposalFlagFilters', () => {
     expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['draft', 'review']).operationFlags);
 
     const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
-    expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['review']).operationFlags);
 
     const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
     expect(memberFlags).toMatchObject(new TransitionFlags().empty);
   });
 
-  it('should allow discussion for review proposals if user is author or admin, as well as reviewed if user is reviewer or admin', async () => {
+  it('should allow discussion for review proposals if user is author, admin or reviewer, as well as reviewed if user is reviewer or admin', async () => {
     const proposalStatus: ProposalStatus = 'review';
 
     const getFlags = proposalFlowFlagFilters[proposalStatus];
@@ -173,13 +173,15 @@ describe('getProposalFlagFilters', () => {
     expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion', 'reviewed']).operationFlags);
 
     const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
-    expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['reviewed']).operationFlags);
+    expect(reviewerFlags).toMatchObject(
+      new TransitionFlags().addPermissions(['discussion', 'reviewed']).operationFlags
+    );
 
     const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
     expect(memberFlags).toMatchObject(new TransitionFlags().empty);
   });
 
-  it('should allow vote_active for reviewed proposals if user is author, admin or reviewer', async () => {
+  it('should allow vote_active for reviewed proposals if user is author, admin or reviewer, and review if user is admin or reviewer', async () => {
     const proposalStatus: ProposalStatus = 'reviewed';
 
     const getFlags = proposalFlowFlagFilters[proposalStatus];
@@ -198,10 +200,10 @@ describe('getProposalFlagFilters', () => {
 
     // Check for admin permissions
     const adminFlags = await getFlags({ userId: admin.id, proposal });
-    expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active']).operationFlags);
+    expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active', 'review']).operationFlags);
 
     const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
-    expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active']).operationFlags);
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active', 'review']).operationFlags);
 
     const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
     expect(memberFlags).toMatchObject(new TransitionFlags().empty);
@@ -266,7 +268,7 @@ describe('getProposalFlagFilters', () => {
   });
 
   describe('getProposalFlagFilters - rubric evaluations', () => {
-    it('should allow draft and evaluation_active state for discussion proposals if user is author or admin', async () => {
+    it('should allow draft for discussion proposals if user is author or admin, and evaluation_active if user is author, admin or reviewer', async () => {
       const proposalStatus: ProposalStatus = 'discussion';
 
       const getFlags = proposalFlowFlagFilters[proposalStatus];
@@ -293,13 +295,13 @@ describe('getProposalFlagFilters', () => {
       );
 
       const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
-      expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+      expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['evaluation_active']).operationFlags);
 
       const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
       expect(memberFlags).toMatchObject(new TransitionFlags().empty);
     });
 
-    it('should allow discussion for evaluation_active proposals if user is author, admin or reviewer, as well as evaluation_closed if user is admin', async () => {
+    it('should allow discussion for evaluation_active proposals if user is author, admin or reviewer, as well as evaluation_closed if user is admin or reviewer', async () => {
       const proposalStatus: ProposalStatus = 'evaluation_active';
 
       const getFlags = proposalFlowFlagFilters[proposalStatus];
@@ -323,7 +325,9 @@ describe('getProposalFlagFilters', () => {
       );
 
       const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
-      expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion']).operationFlags);
+      expect(reviewerFlags).toMatchObject(
+        new TransitionFlags().addPermissions(['discussion', 'evaluation_closed']).operationFlags
+      );
 
       const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
       expect(memberFlags).toMatchObject(new TransitionFlags().empty);

--- a/src/lib/permissions/proposals/__tests__/proposalFlowFlags.spec.ts
+++ b/src/lib/permissions/proposals/__tests__/proposalFlowFlags.spec.ts
@@ -95,7 +95,7 @@ beforeAll(async () => {
   });
 });
 describe('getProposalFlagFilters', () => {
-  it('should allow discussion state for draft proposals if user author or admin', async () => {
+  it('should allow discussion state for draft proposals if user is author or admin', async () => {
     const proposalStatus: ProposalStatus = 'draft';
 
     const getFlags = proposalFlowFlagFilters[proposalStatus];

--- a/src/lib/permissions/proposals/__tests__/proposalFlowFlags.spec.ts
+++ b/src/lib/permissions/proposals/__tests__/proposalFlowFlags.spec.ts
@@ -1,0 +1,360 @@
+// File: __tests__/getProposalFlagFilters.test.ts
+
+import type { ProposalCategory, ProposalStatus, Space, User } from '@prisma/client';
+
+import { prisma } from '../../../../prisma-client';
+import { generateProposal, generateProposalCategory } from '../../../testing/proposals';
+import { generateSpaceUser, generateUserAndSpace } from '../../../testing/user';
+import { hasAccessToSpace } from '../../hasAccessToSpace';
+import { AvailableProposalPermissions } from '../availableProposalPermissions.class';
+import { isProposalAuthor } from '../isProposalAuthor';
+import { isProposalReviewer } from '../isProposalReviewer';
+import type { GetFlagsInput, ProposalFlowPermissionFlags } from '../proposalFlowFlags';
+import { getProposalFlagFilters, TransitionFlags } from '../proposalFlowFlags';
+
+let proposalAuthor: User;
+let admin: User;
+let reviewerUser: User;
+let spaceMember: User;
+let space: Space;
+let proposalCategory: ProposalCategory;
+let proposalFlowFlagFilters: Record<ProposalStatus, (args: GetFlagsInput) => Promise<ProposalFlowPermissionFlags>>;
+
+beforeAll(async () => {
+  // Generate a user, admin, and space for use in tests
+  ({ user: proposalAuthor, space } = await generateUserAndSpace({ isAdmin: false }));
+  admin = await generateSpaceUser({ isAdmin: true, spaceId: space.id });
+  reviewerUser = await generateSpaceUser({ isAdmin: false, spaceId: space.id });
+  spaceMember = await generateSpaceUser({ isAdmin: false, spaceId: space.id });
+
+  // Generate a mock proposal linked to the space
+  proposalCategory = await generateProposalCategory({
+    spaceId: space.id,
+    proposalCategoryPermissions: [{ assignee: { group: 'space', id: space.id }, permissionLevel: 'full_access' }]
+  });
+
+  proposalFlowFlagFilters = await getProposalFlagFilters({
+    isProposalReviewer,
+    countReviewers: ({ proposal }) => proposal.reviewers.length,
+    // Simplified version of computeProposalPermissions from the free tier
+    computeProposalPermissions: async ({ resourceId, userId }) => {
+      const proposal = await prisma.proposal.findUniqueOrThrow({
+        where: { id: resourceId },
+        select: {
+          id: true,
+          status: true,
+          categoryId: true,
+          spaceId: true,
+          createdBy: true,
+          authors: true,
+          reviewers: true
+        }
+      });
+      const { spaceRole, isAdmin } = await hasAccessToSpace({
+        spaceId: proposal.spaceId,
+        userId
+      });
+
+      const permissions = new AvailableProposalPermissions();
+
+      if (isAdmin) {
+        return { ...permissions.full, make_public: false };
+      }
+
+      if (spaceRole) {
+        if (isProposalAuthor({ proposal, userId })) {
+          permissions.addPermissions([
+            'edit',
+            'view',
+            'create_vote',
+            'delete',
+            'vote',
+            'comment',
+            'archive',
+            'unarchive'
+          ]);
+        }
+
+        const isReviewer = isProposalReviewer({
+          proposal,
+          userId
+        });
+
+        if (isReviewer) {
+          permissions.addPermissions(['view', 'comment', 'review', 'evaluate', 'create_vote']);
+        }
+
+        // Add default space member permissions
+        permissions.addPermissions(['view', 'comment', 'vote']);
+      }
+
+      permissions.addPermissions(['view']);
+
+      return permissions.operationFlags;
+    }
+  });
+});
+describe('getProposalFlagFilters', () => {
+  it('should allow discussion state for draft proposals if user author or admin', async () => {
+    const proposalStatus: ProposalStatus = 'draft';
+
+    const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+    const proposal = await generateProposal({
+      spaceId: space.id,
+      userId: proposalAuthor.id,
+      categoryId: proposalCategory.id,
+      proposalStatus,
+      reviewers: [{ group: 'user', id: reviewerUser.id }]
+    });
+
+    // Check for author permissions
+    const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+    expect(authorFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion']).operationFlags);
+
+    // Check for admin permissions
+    const adminFlags = await getFlags({ userId: admin.id, proposal });
+    expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion']).operationFlags);
+
+    const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+
+    const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+    expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+  });
+
+  it('should allow draft and review state for discussion proposals if user is author or admin', async () => {
+    const proposalStatus: ProposalStatus = 'discussion';
+
+    const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+    const proposal = await generateProposal({
+      spaceId: space.id,
+      userId: proposalAuthor.id,
+      categoryId: proposalCategory.id,
+      proposalStatus,
+      reviewers: [{ group: 'user', id: reviewerUser.id }]
+    });
+
+    // Check for author permissions
+    const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+    expect(authorFlags).toMatchObject(new TransitionFlags().addPermissions(['draft', 'review']).operationFlags);
+
+    // Check for admin permissions
+    const adminFlags = await getFlags({ userId: admin.id, proposal });
+    expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['draft', 'review']).operationFlags);
+
+    const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+
+    const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+    expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+  });
+
+  it('should allow discussion for review proposals if user is author or admin, as well as reviewed if user is reviewer or admin', async () => {
+    const proposalStatus: ProposalStatus = 'review';
+
+    const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+    const proposal = await generateProposal({
+      spaceId: space.id,
+      userId: proposalAuthor.id,
+      categoryId: proposalCategory.id,
+      proposalStatus,
+      reviewers: [{ group: 'user', id: reviewerUser.id }]
+    });
+
+    // Check for author permissions
+    const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+    expect(authorFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion']).operationFlags);
+
+    // Check for admin permissions
+    const adminFlags = await getFlags({ userId: admin.id, proposal });
+    expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion', 'reviewed']).operationFlags);
+
+    const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['reviewed']).operationFlags);
+
+    const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+    expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+  });
+
+  it('should allow vote_active for reviewed proposals if user is author, admin or reviewer', async () => {
+    const proposalStatus: ProposalStatus = 'reviewed';
+
+    const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+    const proposal = await generateProposal({
+      spaceId: space.id,
+      userId: proposalAuthor.id,
+      categoryId: proposalCategory.id,
+      proposalStatus,
+      reviewers: [{ group: 'user', id: reviewerUser.id }]
+    });
+
+    // Check for author permissions
+    const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+    expect(authorFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active']).operationFlags);
+
+    // Check for admin permissions
+    const adminFlags = await getFlags({ userId: admin.id, proposal });
+    expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active']).operationFlags);
+
+    const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['vote_active']).operationFlags);
+
+    const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+    expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+  });
+
+  // This reflects current permissions - We might need to change this to allow manual vote closing
+  it('should not allow any status change for vote_active proposals', async () => {
+    const proposalStatus: ProposalStatus = 'vote_active';
+
+    const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+    const proposal = await generateProposal({
+      spaceId: space.id,
+      userId: proposalAuthor.id,
+      categoryId: proposalCategory.id,
+      proposalStatus,
+      reviewers: [{ group: 'user', id: reviewerUser.id }]
+    });
+
+    // Check for author permissions
+    const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+    expect(authorFlags).toMatchObject(new TransitionFlags().empty);
+
+    // Check for admin permissions
+    const adminFlags = await getFlags({ userId: admin.id, proposal });
+    expect(adminFlags).toMatchObject(new TransitionFlags().empty);
+
+    const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+
+    const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+    expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+  });
+
+  // This reflects current permissions - We might need to change this to allow manual vote reopening
+  it('should not allow any status change for vote_closed proposals', async () => {
+    const proposalStatus: ProposalStatus = 'vote_closed';
+
+    const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+    const proposal = await generateProposal({
+      spaceId: space.id,
+      userId: proposalAuthor.id,
+      categoryId: proposalCategory.id,
+      proposalStatus,
+      reviewers: [{ group: 'user', id: reviewerUser.id }]
+    });
+
+    // Check for author permissions
+    const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+    expect(authorFlags).toMatchObject(new TransitionFlags().empty);
+
+    // Check for admin permissions
+    const adminFlags = await getFlags({ userId: admin.id, proposal });
+    expect(adminFlags).toMatchObject(new TransitionFlags().empty);
+
+    const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+    expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+
+    const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+    expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+  });
+
+  describe('getProposalFlagFilters - rubric evaluations', () => {
+    it('should allow draft and evaluation_active state for discussion proposals if user is author or admin', async () => {
+      const proposalStatus: ProposalStatus = 'discussion';
+
+      const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+      const proposal = await generateProposal({
+        spaceId: space.id,
+        userId: proposalAuthor.id,
+        categoryId: proposalCategory.id,
+        proposalStatus,
+        evaluationType: 'rubric',
+        reviewers: [{ group: 'user', id: reviewerUser.id }]
+      });
+
+      // Check for author permissions
+      const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+      expect(authorFlags).toMatchObject(
+        new TransitionFlags().addPermissions(['draft', 'evaluation_active']).operationFlags
+      );
+
+      // Check for admin permissions
+      const adminFlags = await getFlags({ userId: admin.id, proposal });
+      expect(adminFlags).toMatchObject(
+        new TransitionFlags().addPermissions(['draft', 'evaluation_active']).operationFlags
+      );
+
+      const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+      expect(reviewerFlags).toMatchObject(new TransitionFlags().empty);
+
+      const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+      expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+    });
+
+    it('should allow discussion for evaluation_active proposals if user is author, admin or reviewer, as well as evaluation_closed if user is admin', async () => {
+      const proposalStatus: ProposalStatus = 'evaluation_active';
+
+      const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+      const proposal = await generateProposal({
+        spaceId: space.id,
+        userId: proposalAuthor.id,
+        categoryId: proposalCategory.id,
+        proposalStatus,
+        reviewers: [{ group: 'user', id: reviewerUser.id }]
+      });
+
+      // Check for author permissions
+      const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+      expect(authorFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion']).operationFlags);
+
+      // Check for admin permissions
+      const adminFlags = await getFlags({ userId: admin.id, proposal });
+      expect(adminFlags).toMatchObject(
+        new TransitionFlags().addPermissions(['discussion', 'evaluation_closed']).operationFlags
+      );
+
+      const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+      expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['discussion']).operationFlags);
+
+      const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+      expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+    });
+
+    it('should allow evaluation_active for evaluation_closed proposals if user is admin or reviewer', async () => {
+      const proposalStatus: ProposalStatus = 'evaluation_closed';
+
+      const getFlags = proposalFlowFlagFilters[proposalStatus];
+
+      const proposal = await generateProposal({
+        spaceId: space.id,
+        userId: proposalAuthor.id,
+        categoryId: proposalCategory.id,
+        proposalStatus,
+        reviewers: [{ group: 'user', id: reviewerUser.id }]
+      });
+
+      // Check for author permissions
+      const authorFlags = await getFlags({ userId: proposalAuthor.id, proposal });
+      expect(authorFlags).toMatchObject(new TransitionFlags().empty);
+
+      // Check for admin permissions
+      const adminFlags = await getFlags({ userId: admin.id, proposal });
+      expect(adminFlags).toMatchObject(new TransitionFlags().addPermissions(['evaluation_active']).operationFlags);
+
+      const reviewerFlags = await getFlags({ userId: reviewerUser.id, proposal });
+      expect(reviewerFlags).toMatchObject(new TransitionFlags().addPermissions(['evaluation_active']).operationFlags);
+
+      const memberFlags = await getFlags({ userId: spaceMember.id, proposal });
+      expect(memberFlags).toMatchObject(new TransitionFlags().empty);
+    });
+  });
+});

--- a/src/lib/permissions/proposals/proposalFlowFlags.ts
+++ b/src/lib/permissions/proposals/proposalFlowFlags.ts
@@ -72,7 +72,7 @@ function withDepsInReviewProposal({ isProposalReviewer }: GetFlagFilterDependenc
         spaceId: proposal.spaceId,
         userId
       })
-    ).isAdmin;
+    ).spaceRole?.isAdmin;
 
     if (isAdmin) {
       flags.addPermissions(['discussion', 'reviewed']);


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
Extended permissions, also added missing permission flags