### PR TITLE
export prisma client from /prisma namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.9.3",
+  "version": "0.9.4-rc-prisma-export.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.9.5",
+  "version": "0.9.6-rc-prisma-export.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,1 +1,21 @@
+import type { Prisma } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
+
 export * from '@prisma/client';
+
+// @ts-ignore - add support for JSON for BigInt (used in telegramuser) - https://github.com/GoogleChromeLabs/jsbi/issues/30
+// eslint-disable-next-line no-extend-native
+BigInt.prototype.toJSON = function () {
+  return this.toString();
+};
+export const prisma: PrismaClient = (global as any).prisma || new PrismaClient();
+
+// remember this instance of prisma in development to avoid too many clients
+if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+  (global as any).prisma = prisma;
+}
+export type PrismaTransactionClient = PrismaClient | Prisma.TransactionClient;
+
+// Pass a transaction from outer scope of function calling this
+export type PrismaTransaction = { tx: PrismaTransactionClient };
+export type OptionalPrismaTransaction = Partial<PrismaTransaction>;


### PR DESCRIPTION
### WHAT
copilot:summary

### WHY
minor improvement: I noticed that I can import types from @charmverse/core/prisma-client. I don't know if this was always the case, but it seems like we can just use a single export now for the types and prisma client