### PR TITLE
Enforce unique safe transaction hashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.9.4",
+  "version": "0.11.3-rc-safe-unique-tx.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20231129155649_unique_safe_tx_hash/migration.sql
+++ b/src/prisma/migrations/20231129155649_unique_safe_tx_hash/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[safeTxHash]` on the table `Transaction` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Transaction_safeTxHash_key" ON "Transaction"("safeTxHash");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -910,6 +910,8 @@ model Transaction {
   application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
 
   @@index([applicationId])
+
+  @@unique([safeTxHash])
 }
 
 model TokenGate {


### PR DESCRIPTION
### WHAT

Enforce unique gnosis transaction hashes


### WHY

Given safe is idempotent, this prevents adding multiple identical safe transactions for different reward applications