### PR TITLE
add voteSettings to evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,4 @@ This way, your code is merged into main without making production changes.
 And Core workflow will then kick off the Core package update in downstream repos automatically.
 No reinstalling of Core package is necessary.
 
-
 Find out more about CharmVerse at https://www.charmverse.io

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.14.1",
+  "version": "0.14.2-rc-evaluation-vote.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.14.3",
+  "version": "0.14.4-rc-evaluation-vote.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.14.1-rc-evaluation-vote.0",
+  "version": "0.14.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.13.0",
+  "version": "0.14.1-rc-evaluation-vote.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/testing/__tests__/proposals.spec.ts
+++ b/src/lib/testing/__tests__/proposals.spec.ts
@@ -242,45 +242,33 @@ describe('generateProposal', () => {
 
     expect(createdEvaluationSteps).toMatchObject(
       expect.arrayContaining<ProposalEvaluation>([
-        {
+        expect.objectContaining({
           completedAt: rubricStep.completedAt as Date,
           id: expect.any(String),
           index: 0,
           proposalId: proposal.id,
-          result: null,
-          snapshotExpiry: null,
-          snapshotId: null,
           title: expect.any(String),
-          type: 'rubric',
-          voteId: null,
-          decidedBy: null
-        },
-        {
+          type: 'rubric'
+        }),
+        expect.objectContaining({
           completedAt: passFailStep.completedAt as Date,
           id: passFailStep.id as string,
           index: 1,
           proposalId: proposal.id,
           result: 'pass',
-          snapshotExpiry: null,
-          snapshotId: null,
           title: expect.any(String),
-          type: 'pass_fail',
-          voteId: null,
-          decidedBy: null
-        },
-        {
-          completedAt: null,
+          type: 'pass_fail'
+        }),
+        expect.objectContaining({
           id: expect.any(String),
           index: 2,
           proposalId: proposal.id,
-          result: null,
           snapshotExpiry: voteStep.snapshotExpiry as Date,
           snapshotId: voteStep.snapshotId as string,
           title: expect.any(String),
           type: 'vote',
-          voteId: voteStep.voteId as string,
-          decidedBy: null
-        }
+          voteId: voteStep.voteId as string
+        })
       ])
     );
 

--- a/src/prisma/migrations/20231213040736_additional_identity_type/migration.sql
+++ b/src/prisma/migrations/20231213040736_additional_identity_type/migration.sql
@@ -1,0 +1,25 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "IdentityType" ADD VALUE 'Lens';
+ALTER TYPE "IdentityType" ADD VALUE 'Farcaster';
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "MemberPropertyType" ADD VALUE 'google';
+ALTER TYPE "MemberPropertyType" ADD VALUE 'telegram';
+ALTER TYPE "MemberPropertyType" ADD VALUE 'wallet';
+
+-- AlterTable
+ALTER TABLE "Space" ADD COLUMN     "primaryMemberIdentity" "IdentityType";

--- a/src/prisma/migrations/20231214073309_add_vote_settings/migration.sql
+++ b/src/prisma/migrations/20231214073309_add_vote_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ProposalEvaluation" ADD COLUMN     "voteSettings" JSONB;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -1232,6 +1232,7 @@ model ProposalEvaluation {
   decider            User?                               @relation(fields: [decidedBy], references: [id], onDelete: SetNull)
   proposalId         String                              @db.Uuid
   proposal           Proposal                            @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+  voteSettings       Json?
   voteId             String?                             @unique @db.Uuid
   vote               Vote?                               @relation(fields: [voteId], references: [id], onDelete: SetNull)
   rubricCriteria     ProposalRubricCriteria[]

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -31,6 +31,8 @@ enum IdentityType {
   UnstoppableDomain
   Google
   VerifiedEmail
+  Lens
+  Farcaster
 }
 
 enum VoteStatus {
@@ -217,6 +219,9 @@ enum MemberPropertyType {
   join_date
   linked_in
   github
+  google
+  telegram
+  wallet
 }
 
 enum MemberPropertyPermissionLevel {
@@ -289,6 +294,7 @@ model Space {
   publicBountyBoard           Boolean?                          @default(false)
   publicProposals             Boolean?                          @default(false)
   xpsEngineId                 String?                           @unique
+  primaryMemberIdentity       IdentityType?
   author                      User                              @relation(fields: [createdBy], references: [id], onDelete: Cascade)
   blocks                      Block[]
   bounties                    Bounty[]


### PR DESCRIPTION
I need users to be able to save vote settings before we actually create them. Currently any vote stored in the db is considered active, we also don't need all the fields, particularly "deadline" which is required, so I decided to just add a settings json for evaluation which we'll use as a template when the step is initiated.