### PR TITLE
Enable getting all permissions for the proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.16.0",
+  "version": "0.16.1-rc-permissions-all.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/permissions/proposals/client/interfaces.ts
+++ b/src/lib/permissions/proposals/client/interfaces.ts
@@ -22,6 +22,15 @@ export type PremiumProposalPermissionsClient = BaseProposalPermissionsClient & {
   computeProposalPermissions: (
     request: PermissionCompute & ProposalPermissionsSwitch
   ) => Promise<ProposalPermissionFlags>;
+
+  /**
+   * A method for getting the users' permissions on each step of the workflow
+   * Each key in the result is permissions for that evaluationId
+   */
+  computeAllProposalEvaluationPermissions: (
+    request: PermissionCompute & ProposalPermissionsSwitch
+  ) => Promise<Record<string, ProposalPermissionFlags>>;
+
   // This will be the new method used for proposals with evaluation step
   getAccessibleProposalIds: (request: ListProposalsRequest & ProposalPermissionsSwitch) => Promise<string[]>;
   computeBaseProposalPermissions: (

--- a/src/lib/permissions/proposals/client/proposalPermissionsHttpClient.ts
+++ b/src/lib/permissions/proposals/client/proposalPermissionsHttpClient.ts
@@ -48,6 +48,12 @@ export class ProposalPermissionsHttpClient
     return GET(`${this.prefix}/compute-proposal-permissions`, request);
   }
 
+  computeAllProposalEvaluationPermissions(
+    request: PermissionCompute
+  ): Promise<Record<string, ProposalPermissionFlags>> {
+    return GET(`${this.prefix}/compute-all-proposal-evaluation-permissions`, request);
+  }
+
   computeProposalEvaluationPermissions(request: PermissionCompute): Promise<ProposalPermissionFlags> {
     return GET(`${this.prefix}/compute-proposal-evaluation-permissions`, request);
   }


### PR DESCRIPTION
### WHAT

Extend permissions API Client

### WHY

We want ability to get permissions for a user throughout evaluation step