### PR TITLE
add xps user ids to all space roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.29.3",
+  "version": "0.29.4-rc-xps-user-ids.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/log/logLevel.ts
+++ b/src/lib/log/logLevel.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { datadogLogs } from '@datadog/browser-logs';
 import { RateLimit } from 'async-sema';
 import type { Logger, LogLevelDesc } from 'loglevel';

--- a/src/lib/permissions/__tests__/hasAccessToSpace.spec.ts
+++ b/src/lib/permissions/__tests__/hasAccessToSpace.spec.ts
@@ -55,17 +55,19 @@ describe('hasAccessToSpace', () => {
     });
 
     expect(isAdmin).toBe(true);
-    expect(spaceRole).toMatchObject<SpaceRole>({
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      isAdmin: true,
-      isGuest: false,
-      joinedViaLink: null,
-      onboarded: expect.any(Boolean),
-      spaceId: space.id,
-      tokenGateId: null,
-      userId: adminUser.id
-    });
+    expect(spaceRole).toMatchObject<SpaceRole>(
+      expect.objectContaining({
+        createdAt: expect.any(Date),
+        id: expect.any(String),
+        isAdmin: true,
+        isGuest: false,
+        joinedViaLink: null,
+        onboarded: expect.any(Boolean),
+        spaceId: space.id,
+        tokenGateId: null,
+        userId: adminUser.id
+      })
+    );
   });
 
   it('should return success and admin status of the member user', async () => {
@@ -74,17 +76,19 @@ describe('hasAccessToSpace', () => {
       userId: memberUser.id
     });
     expect(isAdmin).toBe(false);
-    expect(spaceRole).toMatchObject<SpaceRole>({
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      isAdmin: false,
-      isGuest: false,
-      joinedViaLink: null,
-      onboarded: expect.any(Boolean),
-      spaceId: space.id,
-      tokenGateId: null,
-      userId: memberUser.id
-    });
+    expect(spaceRole).toMatchObject<SpaceRole>(
+      expect.objectContaining({
+        createdAt: expect.any(Date),
+        id: expect.any(String),
+        isAdmin: false,
+        isGuest: false,
+        joinedViaLink: null,
+        onboarded: expect.any(Boolean),
+        spaceId: space.id,
+        tokenGateId: null,
+        userId: memberUser.id
+      })
+    );
   });
 
   it('should return success if user is a guest', async () => {
@@ -94,17 +98,19 @@ describe('hasAccessToSpace', () => {
     });
 
     expect(isAdmin).toBe(false);
-    expect(spaceRole).toMatchObject<SpaceRole>({
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      isAdmin: false,
-      isGuest: true,
-      joinedViaLink: null,
-      onboarded: expect.any(Boolean),
-      spaceId: space.id,
-      tokenGateId: null,
-      userId: guestUser.id
-    });
+    expect(spaceRole).toMatchObject<SpaceRole>(
+      expect.objectContaining({
+        createdAt: expect.any(Date),
+        id: expect.any(String),
+        isAdmin: false,
+        isGuest: true,
+        joinedViaLink: null,
+        onboarded: expect.any(Boolean),
+        spaceId: space.id,
+        tokenGateId: null,
+        userId: guestUser.id
+      })
+    );
   });
 
   it('should return a null space role for non space members', async () => {
@@ -165,15 +171,13 @@ describe('hasAccessToSpace', () => {
   });
 
   it('should throw an error if a spaceRole is provided that does not match the provided userId and spaceId', async () => {
-    const mockSpaceRole: SpaceRole = {
+    const mockSpaceRole = {
       createdAt: new Date(),
       id: uuid(),
       isAdmin: false,
       isGuest: true,
-      joinedViaLink: null,
       onboarded: true,
       spaceId: uuid(),
-      tokenGateId: null,
       userId: uuid()
     };
     await expect(

--- a/src/lib/permissions/core/interfaces.ts
+++ b/src/lib/permissions/core/interfaces.ts
@@ -27,13 +27,15 @@ export type PermissionCompute = {
   resourceId: string;
   userId?: string;
 };
+
+export type SpaceRoleFields = Pick<SpaceRole, 'id' | 'userId' | 'spaceId' | 'isAdmin' | 'isGuest'>;
 /**
  * Undefined means we don't have a valid compute yet
  *
  * Null means we already computed space role, and the target user does not belong to this space
  */
 export type PreComputedSpaceRole = {
-  preComputedSpaceRole?: SpaceRole | null;
+  preComputedSpaceRole?: SpaceRoleFields | null;
 };
 
 export type PreComputedSpacePermissionFlags = {

--- a/src/lib/permissions/core/policies.ts
+++ b/src/lib/permissions/core/policies.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
-import type { SpaceRole } from '@prisma/client';
-
 import { DataNotFoundError } from '../../errors';
 import { objectUtils } from '../../utilities';
 import { hasAccessToSpace } from '../hasAccessToSpace';
@@ -11,6 +8,7 @@ import type {
   PermissionComputeWithCachedData,
   PreComputedSpacePermissionFlags,
   PreComputedSpaceRole,
+  SpaceRoleFields,
   UserPermissionFlags
 } from './interfaces';
 
@@ -64,19 +62,18 @@ type PolicyBuilderInput<R, F> = {
  * @type R - If the resource contains a spaceId, we can auto resolve admin status. In this case, your Permission Filtering Policies can make use of isAdmin
  * @type P - Additional params the compute function can receive
  */
-export function buildComputePermissionsWithPermissionFilteringPolicies<R, F extends UserPermissionFlags<any>, P = {}>({
-  computeFn,
-  resolver,
-  policies,
-  computeSpacePermissions
-}: PolicyBuilderInput<R, F>): PermissionComputeFn<F, P> {
+export function buildComputePermissionsWithPermissionFilteringPolicies<
+  R,
+  F extends UserPermissionFlags<any>,
+  P = object
+>({ computeFn, resolver, policies, computeSpacePermissions }: PolicyBuilderInput<R, F>): PermissionComputeFn<F, P> {
   return async (request: PermissionComputeWithCachedData): Promise<F> => {
     const resource = request.preFetchedResource ?? (await resolver({ resourceId: request.resourceId }));
     if (!resource) {
       throw new DataNotFoundError(`Could not find resource with ID ${request.resourceId}`);
     }
     // If the resource has a spaceId, we can auto resolve admin status
-    let spaceRole: SpaceRole | undefined | null;
+    let spaceRole: SpaceRoleFields | undefined | null;
     let preComputedSpacePermissionFlags = request.preComputedSpacePermissionFlags;
     const spaceId = (resource as any as ResourceWithSpaceId).spaceId;
 

--- a/src/lib/permissions/hasAccessToSpace.ts
+++ b/src/lib/permissions/hasAccessToSpace.ts
@@ -1,5 +1,3 @@
-import type { SpaceRole } from '@prisma/client';
-
 import { InvalidInputError } from '../../lib/errors';
 import { prisma } from '../../prisma-client';
 import { isUUID } from '../utilities/strings';
@@ -17,7 +15,7 @@ type Input = {
 
 interface Result {
   isAdmin?: boolean;
-  spaceRole: SpaceRole | null;
+  spaceRole: PreComputedSpaceRole['preComputedSpaceRole'] | null;
 }
 
 export async function hasAccessToSpace({ userId, spaceId, preComputedSpaceRole }: Input): Promise<Result> {

--- a/src/prisma/migrations/20240206190023_add_xps_user_field/migration.sql
+++ b/src/prisma/migrations/20240206190023_add_xps_user_field/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[xpsUserId]` on the table `SpaceRole` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "SpaceRole" ADD COLUMN     "xpsUserId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SpaceRole_xpsUserId_key" ON "SpaceRole"("xpsUserId");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -812,6 +812,7 @@ model SpaceRole {
   isAdmin         Boolean           @default(false)
   isGuest         Boolean           @default(false)
   createdAt       DateTime          @default(now())
+  xpsUserId       String?           @unique
   space           Space             @relation(fields: [spaceId], references: [id], onDelete: Cascade)
   user            User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   spaceRoleToRole SpaceRoleToRole[]


### PR DESCRIPTION
add "xpsUserId" to spaceroles, since users have a new user id in each summon tenant