### PR TITLE
add a filter for pages request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.33.0",
+  "version": "0.33.1-rc-page-filter.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.33.1-rc-page-filter.0",
+  "version": "0.33.1-rc-page-filter.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/pages/interfaces.ts
+++ b/src/lib/pages/interfaces.ts
@@ -62,7 +62,7 @@ export type PagesRequest = {
   pageIds?: string[];
   search?: string;
   limit?: number;
-  filter?: 'card' | 'reward' | 'not_card';
+  filter?: 'reward' | 'not_card';
   pageType?: PageType;
 };
 // Page without content and contentText props - used for list of pages (on the client)

--- a/src/lib/pages/interfaces.ts
+++ b/src/lib/pages/interfaces.ts
@@ -62,6 +62,7 @@ export type PagesRequest = {
   pageIds?: string[];
   search?: string;
   limit?: number;
+  filter?: 'card' | 'reward' | 'not_card';
   pageType?: PageType;
 };
 // Page without content and contentText props - used for list of pages (on the client)


### PR DESCRIPTION
we can optimize page load by not retrieving cards by default. I noticed tehre's also a big delay when retrieving rewrad for charmverse, even though we only have about 20. Most of the time is getting page permissions