### PR TITLE
add sidebar_view as an option for pages request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.34.5",
+  "version": "0.34.6-rc-sidebar-view.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/pages/interfaces.ts
+++ b/src/lib/pages/interfaces.ts
@@ -62,7 +62,7 @@ export type PagesRequest = {
   pageIds?: string[];
   search?: string;
   limit?: number;
-  filter?: 'reward' | 'not_card';
+  filter?: 'reward' | 'not_card' | 'sidebar_view';
   pageType?: PageType;
 };
 // Page without content and contentText props - used for list of pages (on the client)


### PR DESCRIPTION
We currently use not_card inside usePages() and then we get pages again w/o any filter. But what i'd like to do is use "sidebar_view" to only retrieve the pages that belong in usePages(), so we can still call getAccessiblePagIds() with no filter when searching by text, to return proposals, bounties, or whatever.

I"m open to other names than 'sidebar_view'. Another option could also be to just return a whitelist of page types unless the 'search' prop is passed in, but i think this is more expressive and maybe we will want to use 'filter' to narrow down the search