### PR TITLE
remove default for reward max submissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.38.5",
+  "version": "0.38.6-rc-remove-submissi.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20240322183720_remove_submissions_default/migration.sql
+++ b/src/prisma/migrations/20240322183720_remove_submissions_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Bounty" ALTER COLUMN "maxSubmissions" DROP DEFAULT;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -888,7 +888,7 @@ model Bounty {
   allowMultipleApplications   Boolean?             @default(false)
   approveSubmitters           Boolean              @default(false)
   submissionsLocked           Boolean              @default(false)
-  maxSubmissions              Int?                 @default(1)
+  maxSubmissions              Int?
   author                      User                 @relation(fields: [createdBy], references: [id])
   space                       Space                @relation(fields: [spaceId], references: [id], onDelete: Cascade)
   applications                Application[]
@@ -2010,7 +2010,7 @@ model IssuedCredential {
   // Fields specific to on chain credentials
   onchainAttestationId String?              @unique
   onchainChainId       Int?
-  hidden               Boolean?              @default(false)
+  hidden               Boolean?             @default(false)
   userId               String               @db.Uuid
   user                 User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
   credentialEvent      CredentialEventType
@@ -2103,17 +2103,15 @@ model ReferralCodeUseEvent {
   @@index([refereeId])
 }
 
-
-
 model PendingSafeTransaction {
-  safeAddress   String
-  safeTxHash    String   @unique
-  chainId       Int
-  processed     Boolean  @default(false)
-  spaceId         String  @db.Uuid
-  space           Space   @relation(fields: [spaceId], references: [id], onDelete: Cascade)
-  schemaId        String
-  proposalIds     String[]
+  safeAddress       String
+  safeTxHash        String   @unique
+  chainId           Int
+  processed         Boolean  @default(false)
+  spaceId           String   @db.Uuid
+  space             Space    @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  schemaId          String
+  proposalIds       String[]
   credentialContent Json?
 
   @@index([spaceId])


### PR DESCRIPTION
There's a bug right now where if someone wants 'infinite' submissions, then the DB pre-populates with 1, even though the UI shows 'infinite' as the default. I am not sure if this affects the product, but if we're expecting a single submission someplace, we can just fix it downstream