### PR TITLE
dont show nodes missing a parent in the page tree for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.38.6",
+  "version": "0.38.7-rc-hide-pages.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/lib/pages/mapPageTree.ts
+++ b/src/lib/pages/mapPageTree.ts
@@ -84,9 +84,9 @@ export function reducePagesToPageTree<T extends PageNode = PageNode>({
       roots.push(node);
     }
     // parent may be undefined if user has no access to it
-    else if (node.parentId && !parentNode) {
-      roots.push(node);
-    }
+    // else if (node.parentId && !parentNode) {
+    //   roots.push(node);
+    // }
 
     if (rootPageIds?.includes(node.id)) {
       roots.push(node);


### PR DESCRIPTION
### WHAT

<!-- what has changed? -->

### WHY

we no longer can tell if a page had a "card" as a parent or its parent is just hidden, since cards are not returned to the pages context

i think we could fix this by querying each page's parent as well and marking them to be hidden or not, but that will take a bit more time