### PR TITLE
delete team members when a project is deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.40.5",
+  "version": "0.40.6-rc-cleanup-team-me.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20240412184457_cascade_delete_members/migration.sql
+++ b/src/prisma/migrations/20240412184457_cascade_delete_members/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "ProjectMember" DROP CONSTRAINT "ProjectMember_projectId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProjectMember" DROP CONSTRAINT "ProjectMember_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ProjectMember" ADD CONSTRAINT "ProjectMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectMember" ADD CONSTRAINT "ProjectMember_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -2167,9 +2167,9 @@ model ProjectMember {
   otherUrl         String?
   previousProjects String?
   userId           String?  @db.Uuid
-  user             User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user             User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
   projectId        String   @db.Uuid
-  project          Project  @relation(fields: [projectId], references: [id])
+  project          Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@index([userId])
 }


### PR DESCRIPTION
We should always define a Cascade rule for foreign keys. This basically just says how to handle relations when you delete something else. If not, we have to remember to manage that logic in our code or delete ops can fail.

Since userId is optional on team members, I changes it to just set the userId to null.