### PR TITLE
Add flag 'Archived by admin' to proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.78.0",
+  "version": "0.78.1-rc-archived-by.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20240819165029_add_admin_archive/migration.sql
+++ b/src/prisma/migrations/20240819165029_add_admin_archive/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Project" ALTER COLUMN "sunnyAwardsNumber" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Proposal" ADD COLUMN     "archivedByAdmin" BOOLEAN DEFAULT false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -1272,6 +1272,7 @@ model Proposal {
   spaceId                         String                              @db.Uuid
   status                          ProposalStatus
   archived                        Boolean?                            @default(false)
+  archivedByAdmin                 Boolean?                            @default(false)
   authors                         ProposalAuthor[]
   reviewers                       ProposalReviewer[]
   space                           Space                               @relation(fields: [spaceId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
This is part of a small feature request for Polygon: If a proposal is archived by admin, authors should not be able to un-archive.

At first i was going to add 'archivedBy' and do a look-up on the user, also considered an 'archivedAt' field.. but those two fields could also be found in a log someplace. By just having 'archivedByAdmin', we don't need to add another JOIN to the proposals lookup, and if the user leaves or changes roles, it won't change the fact this proposal cannot be unarchived
