### PR TITLE
add project source for product updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.81.2",
+  "version": "0.81.3-rc-product-updates.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -284,6 +284,7 @@ enum ProjectSource {
   connect
   sunny_awards
   farcaster
+  product_updates
 }
 
 model Space {


### PR DESCRIPTION
This addition replaces changing the underlying data model for Product Updates and allows us to keep using the current models. We might want to filter these types of projects out of wiki, etc in the future.