### PR TITLE
add deletedAt and mergedTo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.97.1",
+  "version": "0.97.2-rc-deleted-at.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.97.2-rc-deleted-at.0",
+  "version": "0.97.2-rc-deleted-at.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.98.0",
+  "version": "0.98.1-rc-deleted-at.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.97.2-rc-deleted-at.1",
+  "version": "0.97.2-rc-deleted-at.2",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20241205174706_update_scout/migration.sql
+++ b/src/prisma/migrations/20241205174706_update_scout/migration.sql
@@ -1,0 +1,31 @@
+-- AlterTable
+ALTER TABLE "Scout" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "ScoutMergeEvent" (
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "mergedFromId" UUID NOT NULL,
+    "mergedToId" UUID NOT NULL,
+    "mergedRecords" JSONB NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "ScoutMergeEvent_mergedFromId_idx" ON "ScoutMergeEvent"("mergedFromId");
+
+-- CreateIndex
+CREATE INDEX "ScoutMergeEvent_mergedToId_idx" ON "ScoutMergeEvent"("mergedToId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScoutMergeEvent_mergedFromId_mergedToId_key" ON "ScoutMergeEvent"("mergedFromId", "mergedToId");
+
+-- CreateIndex
+CREATE INDEX "Scout_deletedAt_idx" ON "Scout"("deletedAt");
+
+-- CreateIndex
+CREATE INDEX "Scout_builderStatus_idx" ON "Scout"("builderStatus");
+
+-- AddForeignKey
+ALTER TABLE "ScoutMergeEvent" ADD CONSTRAINT "ScoutMergeEvent_mergedFromId_fkey" FOREIGN KEY ("mergedFromId") REFERENCES "Scout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ScoutMergeEvent" ADD CONSTRAINT "ScoutMergeEvent_mergedToId_fkey" FOREIGN KEY ("mergedToId") REFERENCES "Scout"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/migrations/20241205175221_scout_merge_events/migration.sql
+++ b/src/prisma/migrations/20241205175221_scout_merge_events/migration.sql
@@ -19,6 +19,24 @@ CREATE INDEX "ScoutMergeEvent_mergedToId_idx" ON "ScoutMergeEvent"("mergedToId")
 CREATE UNIQUE INDEX "ScoutMergeEvent_mergedFromId_mergedToId_key" ON "ScoutMergeEvent"("mergedFromId", "mergedToId");
 
 -- CreateIndex
+CREATE INDEX "BuilderEvent_type_idx" ON "BuilderEvent"("type");
+
+-- CreateIndex
+CREATE INDEX "BuilderEvent_dailyClaimEventId_idx" ON "BuilderEvent"("dailyClaimEventId");
+
+-- CreateIndex
+CREATE INDEX "BuilderEvent_dailyClaimStreakEventId_idx" ON "BuilderEvent"("dailyClaimStreakEventId");
+
+-- CreateIndex
+CREATE INDEX "BuilderEvent_weeklyClaimId_idx" ON "BuilderEvent"("weeklyClaimId");
+
+-- CreateIndex
+CREATE INDEX "BuilderNft_builderId_idx" ON "BuilderNft"("builderId");
+
+-- CreateIndex
+CREATE INDEX "NFTPurchaseEvent_builderNftId_idx" ON "NFTPurchaseEvent"("builderNftId");
+
+-- CreateIndex
 CREATE INDEX "Scout_deletedAt_idx" ON "Scout"("deletedAt");
 
 -- CreateIndex

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -1537,8 +1537,8 @@ model ProposalRubricCriteria {
 }
 
 model ProposalRubricCriteriaAnswer {
-  createdAt    DateTime            @default(now())
-  updatedAt    DateTime            @default(now())
+  createdAt        DateTime               @default(now())
+  updatedAt        DateTime               @default(now())
   rubricCriteriaId String                 @db.Uuid
   rubricCriteria   ProposalRubricCriteria @relation(fields: [rubricCriteriaId], references: [id], onDelete: Cascade)
   proposalId       String                 @db.Uuid
@@ -2794,6 +2794,9 @@ enum BuilderStatus {
 
 model Scout {
   createdAt                        DateTime                     @default(now())
+  mergedTo                         String?                      @db.Uuid
+  mergedToScout                    Scout?                       @relation(fields: [mergedTo], references: [id], onDelete: SetNull, name: "mergedToScout")
+  deletedAt                        DateTime?
   id                               String                       @id @default(uuid()) @db.Uuid
   email                            String?
   path                             String                       @unique
@@ -2835,6 +2838,7 @@ model Scout {
   referralCode                     String?                      @unique
   referralCodeEvent                ReferralCodeEvent[]
   talentProfile                    TalentProfile?
+  mergedFromScouts                 Scout[]                      @relation("mergedToScout")
 
   @@index([path])
   @@index([farcasterId])

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -2794,8 +2794,6 @@ enum BuilderStatus {
 
 model Scout {
   createdAt                        DateTime                     @default(now())
-  mergedTo                         String?                      @db.Uuid
-  mergedToScout                    Scout?                       @relation(fields: [mergedTo], references: [id], onDelete: SetNull, name: "mergedToScout")
   deletedAt                        DateTime?
   id                               String                       @id @default(uuid()) @db.Uuid
   email                            String?
@@ -2838,11 +2836,25 @@ model Scout {
   referralCode                     String?                      @unique
   referralCodeEvent                ReferralCodeEvent[]
   talentProfile                    TalentProfile?
-  mergedFromScouts                 Scout[]                      @relation("mergedToScout")
+  mergedFromEvents                 ScoutMergeEvent[]            @relation("mergedFromScout")
+  mergedToEvents                   ScoutMergeEvent[]            @relation("mergedToScout")
 
   @@index([path])
   @@index([farcasterId])
   @@index([telegramId])
+}
+
+model ScoutMergeEvent {
+  createdAt       DateTime @default(now())
+  mergedFromId    String   @db.Uuid
+  mergedFromScout Scout    @relation(fields: [mergedFromId], references: [id], onDelete: Cascade, name: "mergedFromScout")
+  mergedToId      String   @db.Uuid
+  mergedToScout   Scout    @relation(fields: [mergedToId], references: [id], onDelete: Cascade, name: "mergedToScout")
+  mergedRecords   Json
+
+  @@unique([mergedFromId, mergedToId])
+  @@index([mergedFromId])
+  @@index([mergedToId])
 }
 
 model BuilderStrike {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -2842,6 +2842,8 @@ model Scout {
   @@index([path])
   @@index([farcasterId])
   @@index([telegramId])
+  @@index([deletedAt])
+  @@index([builderStatus])
 }
 
 model ScoutMergeEvent {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -2916,9 +2916,13 @@ model BuilderEvent {
   referralCodeEvent       ReferralCodeEvent?
 
   @@index([builderId])
+  @@index([type])
   @@index([githubEventId])
   @@index([gemsPayoutEventId])
   @@index([nftPurchaseEventId])
+  @@index([dailyClaimEventId])
+  @@index([dailyClaimStreakEventId])
+  @@index([weeklyClaimId])
 }
 
 model GithubUser {
@@ -3002,6 +3006,7 @@ model NFTPurchaseEvent {
   scoutWallet     ScoutWallet?        @relation(fields: [walletAddress], references: [address], onDelete: Cascade)
 
   @@index([scoutId])
+  @@index([builderNftId])
 }
 
 model GemsPayoutEvent {
@@ -3116,6 +3121,7 @@ model BuilderNft {
   @@unique([contractAddress, tokenId, chainId])
   // Only 1 builder token per season
   @@unique([builderId, season])
+  @@index([builderId])
 }
 
 enum ScoutGameActivityType {


### PR DESCRIPTION
Allows us to merge scout accounts without actually deleting the scout record

This time, I thought we could create a table to track all the things we merge (farcaster id, wallet, etc). The schema will be defined in Typescript. This won't be used by production code but could save a lot of time if we are trying to debug what happened.

Also added a couple indices that should help