### PR TITLE
add model to store email verifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.104.0",
+  "version": "0.104.1-rc-email-verify-mo.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20250107212522_add_email_verification/migration.sql
+++ b/src/prisma/migrations/20250107212522_add_email_verification/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "ScoutEmailVerification" (
+    "code" TEXT NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "email" TEXT NOT NULL,
+    "scoutId" UUID NOT NULL,
+
+    CONSTRAINT "ScoutEmailVerification_pkey" PRIMARY KEY ("code")
+);
+
+-- CreateIndex
+CREATE INDEX "ScoutEmailVerification_completedAt_scoutId_idx" ON "ScoutEmailVerification"("completedAt", "scoutId");
+
+-- AddForeignKey
+ALTER TABLE "ScoutEmailVerification" ADD CONSTRAINT "ScoutEmailVerification_scoutId_fkey" FOREIGN KEY ("scoutId") REFERENCES "Scout"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -2838,13 +2838,25 @@ model Scout {
   talentProfile                    TalentProfile?
   mergedFromEvents                 ScoutMergeEvent[]            @relation("mergedFromScout")
   mergedToEvents                   ScoutMergeEvent[]            @relation("mergedToScout")
-  PartnerRewardEvent               PartnerRewardEvent[]
+  partnerRewardEvents              PartnerRewardEvent[]
+  emailVerifications               ScoutEmailVerification[]
 
   @@index([path])
   @@index([farcasterId])
   @@index([telegramId])
   @@index([deletedAt])
   @@index([builderStatus])
+}
+
+model ScoutEmailVerification {
+  code        String    @id
+  sentAt      DateTime  @default(now())
+  completedAt DateTime?
+  email       String
+  scoutId     String    @db.Uuid
+  scout       Scout     @relation(fields: [scoutId], references: [id], onDelete: Cascade)
+
+  @@index([completedAt, scoutId])
 }
 
 model ScoutMergeEvent {


### PR DESCRIPTION
when sending yuou a verification, we'll create a record with a unique code. When checking your email is validated we will look at this collection (as opposed to adding another field to scout table or something, which would be faster lookups but redundant, possibly incorrect data)