### PR TITLE
bump eas version to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.110.0",
+  "version": "0.110.1-rc-update-eas.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^4.42.2",
-    "@ethereum-attestation-service/eas-sdk": "^0.29.1",
+    "@ethereum-attestation-service/eas-sdk": "^2.7.0",
     "@prisma/client": "^5.7.1",
     "async-sema": "^3.1.1",
     "fetch-retry": "^5.0.6",

--- a/src/lib/protocol/easSchemas/constants.ts
+++ b/src/lib/protocol/easSchemas/constants.ts
@@ -1,4 +1,4 @@
-import { getSchemaUID, SchemaEncoder } from '@ethereum-attestation-service/eas-sdk';
+import { SchemaRegistry, SchemaEncoder } from '@ethereum-attestation-service/eas-sdk';
 
 export const NULL_EAS_REF_UID = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
@@ -8,7 +8,11 @@ export const NULL_EVM_ADDRESS = '0x0000000000000000000000000000000000000000';
 // Obtained from https://github.com/ethereum-attestation-service/eas-contracts/blob/558250dae4cb434859b1ac3b6d32833c6448be21/deploy/scripts/000004-name-initial-schemas.ts#L10C1-L11C1
 export const NAME_SCHEMA_DEFINITION = 'bytes32 schemaId,string name';
 
-export const NAME_SCHEMA_UID = getSchemaUID(NAME_SCHEMA_DEFINITION, NULL_EVM_ADDRESS, true) as `0x${string}`;
+export const NAME_SCHEMA_UID = SchemaRegistry.getSchemaUID(
+  NAME_SCHEMA_DEFINITION,
+  NULL_EVM_ADDRESS,
+  true
+) as `0x${string}`;
 
 export type NameSchemaAttestation = {
   schemaId: `0x${string}`;


### PR DESCRIPTION
The current version has some dependencies with sec vulnerabilities.

Changelog: https://github.com/ethereum-attestation-service/eas-sdk/blob/master/CHANGELOG.md