### PR TITLE
require contract provider to be stated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.123.0",
+  "version": "0.123.1-rc-remove-default.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.123.1",
+  "version": "0.123.2-rc-remove-default.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20250415034354_remove_provider_default/migration.sql
+++ b/src/prisma/migrations/20250415034354_remove_provider_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PartnerRewardPayoutContract" ALTER COLUMN "provider" DROP DEFAULT;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -3685,7 +3685,7 @@ model PartnerRewardPayoutContract {
   deployTxHash    String
   ipfsCid         String
   merkleTreeJson  Json
-  provider        PartnerRewardPayoutContractProvider @default(sablier)
+  provider        PartnerRewardPayoutContractProvider
   blockNumber     BigInt                              @default(0)
   rewardPayouts   PartnerRewardPayout[]
 }


### PR DESCRIPTION
we need to force code to specify provider because there is no natural "default'. For example, if we didn't have a default we might have caught the bug that broke the matchup airdrop before the user encountered it