### PR TITLE
add eventName to contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.125.5-rc-update-cache.0",
+  "version": "0.125.5-rc-update-cache.1",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charmverse/core",
-  "version": "0.125.4",
+  "version": "0.125.5-rc-update-cache.0",
   "description": "Core API for Charmverse",
   "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",

--- a/src/prisma/migrations/20250530163912_update_logs_cache/migration.sql
+++ b/src/prisma/migrations/20250530163912_update_logs_cache/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[contractAddress,chainId,eventName]` on the table `BlockchainLogsContract` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "BlockchainLogsContract_contractAddress_chainId_key";
+
+-- AlterTable
+ALTER TABLE "BlockchainLogsContract" ADD COLUMN     "eventName" TEXT NOT NULL DEFAULT '';
+
+-- CreateIndex
+CREATE INDEX "BlockchainLogsContract_eventName_idx" ON "BlockchainLogsContract"("eventName");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BlockchainLogsContract_contractAddress_chainId_eventName_key" ON "BlockchainLogsContract"("contractAddress", "chainId", "eventName");

--- a/src/prisma/migrations/20250530164111_update_logs_cache/migration.sql
+++ b/src/prisma/migrations/20250530164111_update_logs_cache/migration.sql
@@ -8,7 +8,7 @@
 DROP INDEX "BlockchainLogsContract_contractAddress_chainId_key";
 
 -- AlterTable
-ALTER TABLE "BlockchainLogsContract" ADD COLUMN     "eventName" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "BlockchainLogsContract" ADD COLUMN     "eventName" TEXT;
 
 -- CreateIndex
 CREATE INDEX "BlockchainLogsContract_eventName_idx" ON "BlockchainLogsContract"("eventName");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -4040,13 +4040,15 @@ model BlockchainLogsContract {
   chainId          Int
   firstBlockNumber BigInt
   lastBlockNumber  BigInt?
+  eventName        String          @default("")
   logs             BlockchainLog[]
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt
 
-  @@unique([contractAddress, chainId])
+  @@unique([contractAddress, chainId, eventName])
   @@index([contractAddress])
   @@index([chainId])
+  @@index([eventName])
 }
 
 model BlockchainLog {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -4040,7 +4040,7 @@ model BlockchainLogsContract {
   chainId          Int
   firstBlockNumber BigInt
   lastBlockNumber  BigInt?
-  eventName        String          @default("")
+  eventName        String?
   logs             BlockchainLog[]
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt


### PR DESCRIPTION
i realized we're always querying logs with eventName as a filter, so we need to keep track of the 'latest block number' based on the event requested