### PR TITLE
get readonly status when checking role

### DIFF
--- a/src/lib/permissions/core/interfaces.ts
+++ b/src/lib/permissions/core/interfaces.ts
@@ -1,4 +1,4 @@
-import type { SpaceOperation, SpaceRole, SpaceRoleToRole } from '@prisma/client';
+import type { SpaceOperation, SpaceRole, SpaceRoleToRole, SpaceSubscriptionTier } from '@prisma/client';
 
 export type Resource = {
   resourceId: string;
@@ -35,7 +35,7 @@ export type SpaceRoleFields = Pick<SpaceRole, 'id' | 'userId' | 'spaceId' | 'isA
  * Null means we already computed space role, and the target user does not belong to this space
  */
 export type PreComputedSpaceRole = {
-  preComputedSpaceRole?: SpaceRoleFields | null;
+  preComputedSpaceRole?: (SpaceRoleFields & { space: { subscriptionTier: SpaceSubscriptionTier | null } }) | null;
 };
 
 export type PreComputedSpacePermissionFlags = {

--- a/src/lib/permissions/hasAccessToSpace.ts
+++ b/src/lib/permissions/hasAccessToSpace.ts
@@ -15,6 +15,7 @@ type Input = {
 
 interface Result {
   isAdmin?: boolean;
+  isReadonlySpace: boolean;
   spaceRole: PreComputedSpaceRole['preComputedSpaceRole'] | null;
 }
 
@@ -27,7 +28,7 @@ export async function hasAccessToSpace({ userId, spaceId, preComputedSpaceRole }
   ) {
     throw new InvalidInputError(`SpaceRole userId and spaceId do not match the provided userId and spaceId`);
   } else if (!userId) {
-    return { spaceRole: null };
+    return { spaceRole: null, isReadonlySpace: true };
   }
   const evaluatedSpaceRole =
     preComputedSpaceRole || preComputedSpaceRole === null
@@ -36,10 +37,26 @@ export async function hasAccessToSpace({ userId, spaceId, preComputedSpaceRole }
           where: {
             spaceId,
             userId
+          },
+          select: {
+            id: true,
+            isAdmin: true,
+            isGuest: true,
+            userId: true,
+            spaceId: true,
+            space: {
+              select: {
+                subscriptionTier: true
+              }
+            }
           }
         });
   if (!evaluatedSpaceRole) {
-    return { spaceRole: null };
+    return { spaceRole: null, isReadonlySpace: true };
   }
-  return { isAdmin: evaluatedSpaceRole.isAdmin, spaceRole: evaluatedSpaceRole };
+  return {
+    isAdmin: evaluatedSpaceRole.isAdmin,
+    isReadonlySpace: evaluatedSpaceRole.space.subscriptionTier === 'readonly',
+    spaceRole: evaluatedSpaceRole
+  };
 }

--- a/src/lib/permissions/pages/copyPagePermissions.ts
+++ b/src/lib/permissions/pages/copyPagePermissions.ts
@@ -25,7 +25,7 @@ export function copyPagePermission({
     throw new InvalidPermissionGranteeError();
   }
 
-  const inheritanceValue = inheritFrom ? pagePermission.inheritedFromPermission ?? pagePermission.id : undefined;
+  const inheritanceValue = inheritFrom ? (pagePermission.inheritedFromPermission ?? pagePermission.id) : undefined;
 
   return {
     page: {

--- a/src/lib/testing/user.ts
+++ b/src/lib/testing/user.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionTier, User } from '@prisma/client';
+import type { SpaceSubscriptionTier, SubscriptionTier, User } from '@prisma/client';
 import { v4 as uuid } from 'uuid';
 
 import { prisma } from '../../prisma-client';
@@ -61,6 +61,7 @@ type CreateUserAndSpaceInput = {
   publicProposals?: boolean;
   publicProposalTemplates?: boolean;
   spacePaidTier?: SubscriptionTier;
+  subscriptionTier?: SpaceSubscriptionTier;
   customProposalProperties?: IPropertyTemplate[];
   wallet?: string;
 };
@@ -76,6 +77,7 @@ export async function generateUserAndSpace({
   publicProposals = false,
   publicProposalTemplates = false,
   spacePaidTier = 'community',
+  subscriptionTier = 'gold',
   customProposalProperties,
   wallet
 }: CreateUserAndSpaceInput = {}) {
@@ -98,6 +100,7 @@ export async function generateUserAndSpace({
                 }
               },
               paidTier: spacePaidTier,
+              subscriptionTier,
               updatedBy: userId,
               name: spaceName,
               // Adding prefix avoids this being evaluated as uuid

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  binaryTargets   = ["debian-openssl-3.0.x", "linux-musl", "darwin", "native", "rhel-openssl-1.0.x"]
+  binaryTargets   = ["debian-openssl-3.0.x", "linux-musl", "darwin-arm64", "native", "rhel-openssl-1.0.x"]
   previewFeatures = ["fullTextSearch"]
 }
 


### PR DESCRIPTION
In permissions API, we call hasSpaceRole() when computing permissions. By including space tier, we can also determine if it is readonly and remove create-related permissions